### PR TITLE
Feat/wiki

### DIFF
--- a/Challange_Web_Dev/css/wiki.css
+++ b/Challange_Web_Dev/css/wiki.css
@@ -1,6 +1,45 @@
 /* História da fórmula E */
 
+.container {
+  margin: 3rem auto;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  font-family: var(--font-primary);
+}
 
+.content {
+  padding: 4rem;
+  color: var(--font-primary-color);
+  font-size: 1.2rem;
+  font-weight: 200;
+  border-radius: 0 0 50px 0;
+}
+
+#blue {
+  background-color: var(--font-primary-dark-color);
+  z-index: 2;
+}
+
+#red {
+  background-color: #D5001C;
+  z-index: 1;
+  margin-left: -3rem;
+}
+
+#light-blue {
+  background-color: #0500FF;
+  z-index: 0;
+  margin-left: -3rem;
+}
+
+.title-container {
+  margin-bottom: 1rem;
+
+  h2 {
+    font-weight: 400;
+    font-size: 2rem;
+  }
+}
 
 /* Fim História da fórmula E */
 
@@ -25,8 +64,8 @@
   width: 70%;
   display: flex;
   flex-direction: column;
-  align-items: center; 
-  margin: 0 auto; 
+  align-items: center;
+  margin: 0 auto;
 
   .teams-content-box {
     margin: 1rem 2rem;
@@ -67,7 +106,7 @@
 
   .label-content {
     display: flex;
-    flex-direction: column; 
+    flex-direction: column;
     background: var(--bg-primary);
     color: var(--font-primary-color);
     overflow: hidden;
@@ -84,88 +123,91 @@
     }
   }
 
- 
-  .label.active + .label-content {
+
+  .label.active+.label-content {
     height: auto;
     padding: 1rem;
   }
 
   .label:hover {
-    background-color: #d6d5d5c5;;
+    background-color: #d6d5d5c5;
+    ;
   }
 }
 
 
-  /* Mobile */
+/* Mobile */
 @media only screen and (max-width: 1200px) {
-    .section-container {
-      height: auto;
-      margin-bottom: 2rem;
-      
-    }
-    .content-wrapper {
-      height: 100%;
-      flex-direction: column-reverse;
-      padding: 1rem 0 1rem;
-      align-items: start;
-    }
-  
-    .content {
-      margin-top: 15px;
-      width: 100%;
-    }
-  
-    .image-container {
-      width: 100%;
-      justify-content: center;
-      align-items: flex-start;
-      padding: 0;
-      flex-grow: 0;
-      margin-top: 2rem;
-      img {
-        width: 90%;
-        height: fit-content;
-        object-fit: contain;
-      }
-    }
-  
-    .piloto-wrapper {
-      top: 0 !important;
-    }
+  .section-container {
+    height: auto;
+    margin-bottom: 2rem;
 
-    .circuit-container {
-      p {
-        padding: 2rem;
-        color: var(--color-tertiary);
-        font-size: 1rem;
-      }
-    }
+  }
 
-    .teams-accordion {
-      width: 100%;
-    }
+  .content-wrapper {
+    height: 100%;
+    flex-direction: column-reverse;
+    padding: 1rem 0 1rem;
+    align-items: start;
+  }
 
-    .label {
-      gap: 10px !important; 
-      padding: 1rem !important;
-  
-      img {
-        height: 30px !important;
-      }
-  
-      .title-label {
-        font-size: .8rem !important;
-      }
+  .content {
+    margin-top: 15px;
+    width: 100%;
+  }
+
+  .image-container {
+    width: 100%;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 0;
+    flex-grow: 0;
+    margin-top: 2rem;
+
+    img {
+      width: 90%;
+      height: fit-content;
+      object-fit: contain;
     }
-  
-    .label::before {
-      font-weight: 200;
-      right: 1px;
+  }
+
+  .piloto-wrapper {
+    top: 0 !important;
+  }
+
+  .circuit-container {
+    p {
+      padding: 2rem;
+      color: var(--color-tertiary);
       font-size: 1rem;
     }
+  }
 
-    .label-content {
-      margin-bottom: 2rem;
-      font-size: .9rem !important;
+  .teams-accordion {
+    width: 100%;
+  }
+
+  .label {
+    gap: 10px !important;
+    padding: 1rem !important;
+
+    img {
+      height: 30px !important;
     }
+
+    .title-label {
+      font-size: .8rem !important;
+    }
+  }
+
+  .label::before {
+    font-weight: 200;
+    right: 1px;
+    font-size: 1rem;
+  }
+
+  .label-content {
+    margin-bottom: 2rem;
+    font-size: .9rem !important;
+  }
 }

--- a/Challange_Web_Dev/css/wiki.css
+++ b/Challange_Web_Dev/css/wiki.css
@@ -1,53 +1,9 @@
-h2 {
-  font-style: italic;
-}
+/* História da fórmula E */
 
-.section-container {
-    font-family: var(--font-primary);
-    margin: auto;
-    width: 100%;
-    margin: 3rem 0 10rem;
-    display: flex;
-    align-items: center;
-  }
-  
-  .bg {
-    background-image: url(../img/Web/Banner.png);
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-position: 40%;
-  }
-  
-  .content-wrapper {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    background: var(--bg-primary);
-  }
-  
-  .content {
-    width: 48%;
-    padding: 0 10px 0 30px;
-    display: flex;
-    align-items: start;
-    justify-content: center;
-    flex-direction: column;
 
-    .title-container, h2 {
-        font-size: 40px;
-    }
-  
-    .text-container {
-      padding: 40px 0 40px;
-  
-      p {
-        width: 90%;
-        color: var(--font-primary-color);
-      }
-    }
-  }
+
+/* Fim História da fórmula E */
+
 
 /* Circuitos */
 .circuit-container {
@@ -61,6 +17,8 @@ h2 {
     font-size: 2rem;
   }
 }
+
+/* Fim Circuitos */
 
 /* Equipes */
 .teams-accordion {

--- a/Challange_Web_Dev/css/wiki.css
+++ b/Challange_Web_Dev/css/wiki.css
@@ -144,7 +144,7 @@
 
 /* Equipes */
 .teams-accordion {
-  width: 70%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -155,11 +155,12 @@
   }
 
   .label {
+    width: 100%;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 10rem;
-    padding: 2rem;
+    gap: 20rem;
+    padding: .5rem;
     background-color: #f2f2f2;
     color: #00001B;
     cursor: pointer;
@@ -172,7 +173,8 @@
     .title-label {
       color: #00001B;
       margin: 0;
-      font-size: 3rem;
+      font-size: 1.5rem;
+      font-weight: 500;
     }
   }
 
@@ -181,10 +183,12 @@
     font-family: "Font Awesome 5 Free";
     font-weight: 900;
     top: 50%;
-    right: 2rem;
     transform: translateY(-50%);
-    font-size: 2rem;
     order: 2;
+  }
+
+  .label.active::before {
+    content: "\f077";
   }
 
   .label-content {
@@ -194,29 +198,68 @@
     color: var(--font-primary-color);
     overflow: hidden;
     margin-bottom: 2rem;
-    font-size: 1.3rem;
+    font-size: 1.5rem;
     font-weight: 200;
     transition: .5s ease-in-out;
     height: 0;
-
-    li {
-      list-style: none;
-      font-weight: 300;
-      padding-bottom: 10px;
-    }
   }
 
 
   .label.active+.label-content {
     height: auto;
-    padding: 1rem;
-  }
-
-  .label:hover {
-    background-color: #d6d5d5c5;
-    ;
+    padding: 1.5rem;
   }
 }
+
+.grid-label-content {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+
+  h3 {
+    font-style: italic;
+  }
+}
+
+.pilots-cards {
+  display: flex;
+  flex-direction: column;
+
+}
+
+.bar-color {
+  width: 3%;
+  height: 100%;
+  border-radius: 5px 0 0 5px;
+}
+
+#abt {
+  background-color: var(--cor-abt);
+}
+
+
+.pilot1, .pilot2 {
+  display: flex;
+  align-items: center;
+  gap: 3rem;
+  background-color: #f2f2f2;
+  border-radius: 5px;
+  width: 100%;
+  margin: 1rem;
+
+  img {
+    width: 20%;
+  }
+
+  h1 {
+    font-style: italic;
+    margin-right: 3rem;
+    font-size: 2.5rem;
+    font-weight: 400;
+    color: var(--color-primary);
+  }
+}
+
 
 /* Fim Equipes */
 
@@ -255,7 +298,7 @@
       font-size: 2rem;
     }
   }
-  
+
   /* Fim História da fórmula E */
 
   /* Circuitos */
@@ -282,7 +325,7 @@
   }
 
   .mexico, .diriyah, .misano, .monaco {
-    width:  100%;
+    width: 100%;
   }
 
   .mexico, .diriyah {
@@ -296,6 +339,7 @@
   .circuit-container {
     padding: .7rem;
   }
+
   /*Fim Circuitos */
 
   /* Equipes */

--- a/Challange_Web_Dev/css/wiki.css
+++ b/Challange_Web_Dev/css/wiki.css
@@ -51,15 +51,33 @@
 
 
 /* Circuitos */
+.circuit-grid {
+  margin: 3rem auto;
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
 .circuit-container {
+  width: 50%;
+  background-color: var(--font-primary-dark-color);
+  border-radius: 0 0 55px 0;
+
   img {
     width: 100%;
+    padding-left: 1.5rem;
   }
+}
 
-  p {
-    padding: 3rem;
-    color: var(--color-tertiary);
+.circuit-name {
+  width: 100%;
+  background-color: #f2f2f2;
+  padding: 1rem;
+  border-radius: 0 0 50px 0;
+
+  span {
+    font-weight: 600;
     font-size: 2rem;
+    color: var(--font-primary-dark-color);
   }
 }
 
@@ -221,6 +239,8 @@
     margin-bottom: 2rem;
     font-size: .9rem !important;
   }
+
   /*Fim Equipes */
 }
+
 /*Fim Mobile */

--- a/Challange_Web_Dev/css/wiki.css
+++ b/Challange_Web_Dev/css/wiki.css
@@ -158,8 +158,6 @@
     width: 100%;
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 20rem;
     padding: .5rem;
     background-color: #f2f2f2;
     color: #00001B;
@@ -172,7 +170,7 @@
 
     .title-label {
       color: #00001B;
-      margin: 0;
+      margin-left: 24px;
       font-size: 1.5rem;
       font-weight: 500;
     }
@@ -184,6 +182,7 @@
     font-weight: 900;
     top: 50%;
     transform: translateY(-50%);
+    margin-left: auto;
     order: 2;
   }
 
@@ -200,7 +199,8 @@
     margin-bottom: 2rem;
     font-size: 1.5rem;
     font-weight: 200;
-    transition: .5s ease-in;
+    transition: .5s ease-out;
+
     height: 0;
   }
 

--- a/Challange_Web_Dev/css/wiki.css
+++ b/Challange_Web_Dev/css/wiki.css
@@ -2,9 +2,9 @@
 
 .container {
   margin: 3rem auto;
+  font-family: var(--font-primary);
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  font-family: var(--font-primary);
 }
 
 .content {
@@ -52,34 +52,94 @@
 
 /* Circuitos */
 .circuit-grid {
+  padding: .5rem 3rem;
   margin: 3rem auto;
+}
+
+.grid1, .grid2, .grid3 {
+  gap: 1rem;
+}
+
+.grid1 {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: auto;
+  grid-template-areas:
+    "berlim berlim diriyah"
+    "berlim berlim mexico";
+  margin-bottom: 1rem;
+
+  .berlim {
+    grid-area: berlim;
+  }
+
+  .mexico {
+    grid-area: mexico;
+  }
+
+  .diriyah {
+    grid-area: diriyah;
+  }
+}
+
+.londres {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.grid2 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: auto;
+  grid-template-areas:
+    "misano portland portland"
+    "monaco portland portland";
+  margin-bottom: 1rem;
+
+  .misano {
+    grid-area: misano;
+  }
+  
+  .monaco {
+    grid-area: monaco;
+  }
+
+  .portland {
+    grid-area: portland;
+  }
+}
+
+.mexico, .diriyah, .misano, .monaco{
+  width: 85%;
+}
+
+.mexico, .diriyah {
+  margin-left: 4rem;
+}
+
+.grid3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
 }
 
 .circuit-container {
-  width: 50%;
-  background-color: var(--font-primary-dark-color);
+  width: 100%;
+  padding: 1rem;
   border-radius: 0 0 55px 0;
+  background: var(--bg-primary);
 
   img {
     width: 100%;
-    padding-left: 1.5rem;
+    border-radius: 10px;
   }
-}
-
-.circuit-name {
-  width: 100%;
-  background-color: #f2f2f2;
-  padding: 1rem;
-  border-radius: 0 0 50px 0;
 
   span {
-    font-weight: 600;
+    color: var(--font-primary-color);
+    font-weight: 300;
     font-size: 2rem;
-    color: var(--font-primary-dark-color);
   }
 }
+
 
 /* Fim Circuitos */
 

--- a/Challange_Web_Dev/css/wiki.css
+++ b/Challange_Web_Dev/css/wiki.css
@@ -49,26 +49,6 @@ h2 {
     }
   }
 
-  .image-container {
-    display: flex;
-    align-items: center;
-    flex-grow: 1;
-    padding: 0 100px;
-    width: 48%;
-  
-    .main-image {
-      scale: 1.1;
-      height: 390px;
-      border-radius: 7px;
-      box-shadow: 1px 1px 30px var(--color-shadow);
-      transition: scale 0.7s;
-    }
-  
-    .main-image:hover {
-      scale: 1.2;
-    }
-  }
-
 /* Circuitos */
 .circuit-container {
   img {

--- a/Challange_Web_Dev/css/wiki.css
+++ b/Challange_Web_Dev/css/wiki.css
@@ -149,66 +149,66 @@
   flex-direction: column;
   align-items: center;
   margin: 0 auto;
+}
 
-  .teams-content-box {
-    margin: 1rem 2rem;
+.teams-content-box {
+  margin: 1rem 2rem;
+}
+
+.label {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  padding: .5rem;
+  background-color: #f2f2f2;
+  color: #00001B;
+  cursor: pointer;
+  font-weight: 800;
+
+  img {
+    height: 50px;
   }
+}
+  
 
-  .label {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    padding: .5rem;
-    background-color: #f2f2f2;
-    color: #00001B;
-    cursor: pointer;
-    font-weight: 800;
+.title-label {
+  color: #00001B;
+  margin-left: 24px;
+  font-size: 1.5rem;
+  font-weight: 500;
+}
 
-    img {
-      height: 50px;
-    }
+.label::before {
+  content: "\f078";
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: auto;
+  order: 2;
+}
 
-    .title-label {
-      color: #00001B;
-      margin-left: 24px;
-      font-size: 1.5rem;
-      font-weight: 500;
-    }
-  }
+.label.active::before {
+  content: "\f077";
+}
 
-  .label::before {
-    content: "\f078";
-    font-family: "Font Awesome 5 Free";
-    font-weight: 900;
-    top: 50%;
-    transform: translateY(-50%);
-    margin-left: auto;
-    order: 2;
-  }
-
-  .label.active::before {
-    content: "\f077";
-  }
-
-  .label-content {
-    display: flex;
-    flex-direction: column;
-    background: var(--bg-primary);
-    color: var(--font-primary-color);
-    overflow: hidden;
-    margin-bottom: 2rem;
-    font-size: 1.5rem;
-    font-weight: 200;
-    transition: .5s ease-out;
-
-    height: 0;
-  }
+.label-content {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary);
+  color: var(--font-primary-color);
+  overflow: hidden;
+  margin-bottom: 2rem;
+  font-size: 1.5rem;
+  font-weight: 200;
+  transition: .5s ease-out;
+  height: 0;
+}
 
 
-  .label.active+.label-content {
-    height: auto;
-    padding: 1.5rem;
-  }
+.label.active+.label-content {
+  height: auto;
+  padding: 1.5rem;
 }
 
 .grid-label-content {
@@ -227,11 +227,11 @@
   }
 }
 
+
 .pilots-cards {
   grid-area: pilot;
   display: flex;
   flex-direction: column;
-
 }
 
 .bar-color {
@@ -244,6 +244,45 @@
   background-color: var(--cor-abt);
 }
 
+#andretti {
+  background-color: var(--cor-andretti);
+}
+
+#ds {
+  background-color: var(--cor-ds-penske);
+}
+
+#env {
+  background-color: var(--cor-envision);
+}
+
+#ert {
+  background-color: var(--cor-ert);
+}
+
+#jaguar {
+  background-color: var(--cor-jaguar);
+}
+
+#mah {
+  background-color: var(--cor-mahindra);
+}
+
+#mas {
+  background-color: var(--cor-maseratti);
+}
+
+#mcl {
+  background-color: var(--cor-mclaren);
+}
+
+#nissan {
+  background-color: var(--cor-nissan);
+}
+
+#porsche {
+  background-color: var(--cor-porsche);
+}
 
 .pilot1, .pilot2 {
   display: flex;
@@ -307,6 +346,46 @@
   color: var(--cor-abt);
 }
 
+#icon-andretti {
+  color: var(--cor-andretti);
+}
+
+#icon-ds {
+  color: var(--cor-ds-penske);
+}
+
+#icon-env {
+  color: var(--cor-envision);
+}
+
+#icon-ert {
+  color: var(--cor-ert);
+}
+
+#icon-jaguar {
+  color: var(--cor-jaguar);
+}
+
+#icon-mah {
+  color: var(--cor-mahindra);
+}
+
+#icon-mas {
+  color: var(--cor-maseratti);
+}
+
+#icon-mcl {
+  color: var(--cor-mclaren);
+}
+
+#icon-nissan {
+  color: var(--cor-nissan);
+}
+
+#icon-porsche {
+  color: var(--cor-porsche);
+}
+
 .position-number, .victory-number, .podium-number {
   background-color: #f2f2f2;
   padding: 1rem;
@@ -322,8 +401,6 @@
 .podium-number {
   border-radius: 0 5px 5px 0;
 }
-
-
 /* Fim Equipes */
 
 
@@ -406,34 +483,7 @@
   /*Fim Circuitos */
 
   /* Equipes */
-  .teams-accordion {
-    width: 100%;
-  }
-
-  .label {
-    gap: 10px !important;
-    padding: 1rem !important;
-
-    img {
-      height: 30px !important;
-    }
-
-    .title-label {
-      font-size: .8rem !important;
-    }
-  }
-
-  .label::before {
-    font-weight: 200;
-    right: 1px;
-    font-size: 1rem;
-  }
-
-  .label-content {
-    margin-bottom: 2rem;
-    font-size: .9rem !important;
-  }
-
+  
   /*Fim Equipes */
 }
 

--- a/Challange_Web_Dev/css/wiki.css
+++ b/Challange_Web_Dev/css/wiki.css
@@ -23,13 +23,19 @@
 #red {
   background-color: #D5001C;
   z-index: 1;
-  margin-left: -3rem;
 }
 
 #light-blue {
   background-color: #0500FF;
   z-index: 0;
+}
+
+#red, #light-blue {
   margin-left: -3rem;
+
+  h2, p {
+    margin-left: 1rem;
+  }
 }
 
 .title-container {
@@ -135,46 +141,48 @@
   }
 }
 
+/* Fim Equipes */
+
 
 /* Mobile */
 @media only screen and (max-width: 1200px) {
-  .section-container {
-    height: auto;
-    margin-bottom: 2rem;
 
-  }
-
-  .content-wrapper {
-    height: 100%;
-    flex-direction: column-reverse;
-    padding: 1rem 0 1rem;
-    align-items: start;
+  /* História da fórmula E */
+  .container {
+    grid-template-columns: 1fr;
   }
 
   .content {
-    margin-top: 15px;
-    width: 100%;
+    padding: 3rem;
+
   }
 
-  .image-container {
-    width: 100%;
-    justify-content: center;
-    align-items: flex-start;
-    padding: 0;
-    flex-grow: 0;
-    margin-top: 2rem;
+  #red, #light-blue {
+    margin-left: 0;
+    margin-top: -2.5rem;
 
-    img {
-      width: 90%;
-      height: fit-content;
-      object-fit: contain;
+    h2 {
+      margin-top: 2rem;
+    }
+
+    h2, p {
+      margin-left: 0;
     }
   }
 
-  .piloto-wrapper {
-    top: 0 !important;
+  .title-container {
+    margin-bottom: 1rem;
+
+    h2 {
+      font-weight: 400;
+      font-size: 2rem;
+    }
   }
 
+  /* Fim História da fórmula E */
+
+
+  /* Circuitos */
   .circuit-container {
     p {
       padding: 2rem;
@@ -183,6 +191,9 @@
     }
   }
 
+  /*Fim Circuitos */
+
+  /* Equipes */
   .teams-accordion {
     width: 100%;
   }
@@ -210,4 +221,6 @@
     margin-bottom: 2rem;
     font-size: .9rem !important;
   }
+  /*Fim Equipes */
 }
+/*Fim Mobile */

--- a/Challange_Web_Dev/css/wiki.css
+++ b/Challange_Web_Dev/css/wiki.css
@@ -99,7 +99,7 @@
   .misano {
     grid-area: misano;
   }
-  
+
   .monaco {
     grid-area: monaco;
   }
@@ -109,7 +109,7 @@
   }
 }
 
-.mexico, .diriyah, .misano, .monaco{
+.mexico, .diriyah, .misano, .monaco {
   width: 85%;
 }
 
@@ -139,7 +139,6 @@
     font-size: 2rem;
   }
 }
-
 
 /* Fim Circuitos */
 
@@ -256,19 +255,47 @@
       font-size: 2rem;
     }
   }
-
+  
   /* Fim História da fórmula E */
 
-
   /* Circuitos */
-  .circuit-container {
-    p {
-      padding: 2rem;
-      color: var(--color-tertiary);
-      font-size: 1rem;
-    }
+  .circuit-grid {
+    padding: .5rem 1rem;
+    margin: 1rem auto;
+    gap: .5rem;
   }
 
+  .grid1 {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "berlim"
+      "mexico"
+      "diriyah";
+  }
+
+  .grid2 {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "misano"
+      "monaco"
+      "portland";
+  }
+
+  .mexico, .diriyah, .misano, .monaco {
+    width:  100%;
+  }
+
+  .mexico, .diriyah {
+    margin-left: 0;
+  }
+
+  .grid3 {
+    grid-template-columns: 1fr;
+  }
+
+  .circuit-container {
+    padding: .7rem;
+  }
   /*Fim Circuitos */
 
   /* Equipes */

--- a/Challange_Web_Dev/css/wiki.css
+++ b/Challange_Web_Dev/css/wiki.css
@@ -52,61 +52,60 @@
 
 /* Circuitos */
 .circuit-grid {
-  padding: .5rem 3rem;
+  padding: 0.5rem 3rem;
   margin: 3rem auto;
 }
 
 .grid1, .grid2, .grid3 {
+  display: grid;
   gap: 1rem;
+  margin-bottom: 1rem;
 }
 
 .grid1 {
-  display: grid;
   grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: auto;
   grid-template-areas:
     "berlim berlim diriyah"
     "berlim berlim mexico";
-  margin-bottom: 1rem;
+}
 
-  .berlim {
-    grid-area: berlim;
-  }
+.grid1 .berlim {
+  grid-area: berlim;
+}
 
-  .mexico {
-    grid-area: mexico;
-  }
+.grid1 .mexico {
+  grid-area: mexico;
+}
 
-  .diriyah {
-    grid-area: diriyah;
-  }
+.grid1 .diriyah {
+  grid-area: diriyah;
 }
 
 .londres {
-  width: 100%;
   margin-bottom: 1rem;
 }
 
 .grid2 {
-  display: grid;
   grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: auto;
   grid-template-areas:
     "misano portland portland"
     "monaco portland portland";
-  margin-bottom: 1rem;
+}
 
-  .misano {
-    grid-area: misano;
-  }
+.grid2 .misano {
+  grid-area: misano;
+}
 
-  .monaco {
-    grid-area: monaco;
-  }
+.grid2 .monaco {
+  grid-area: monaco;
+}
 
-  .portland {
-    grid-area: portland;
-  }
+.grid2 .portland {
+  grid-area: portland;
+}
+
+.grid3 {
+  grid-template-columns: repeat(3, 1fr);
 }
 
 .mexico, .diriyah, .misano, .monaco {
@@ -114,13 +113,9 @@
 }
 
 .mexico, .diriyah {
-  margin-left: 4rem;
+  margin-left: 15%;
 }
 
-.grid3 {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-}
 
 .circuit-container {
   width: 100%;
@@ -139,6 +134,8 @@
     font-size: 2rem;
   }
 }
+
+
 
 /* Fim Circuitos */
 
@@ -169,7 +166,7 @@
     height: 50px;
   }
 }
-  
+
 
 .title-label {
   color: #00001B;
@@ -401,6 +398,7 @@
 .podium-number {
   border-radius: 0 5px 5px 0;
 }
+
 /* Fim Equipes */
 
 
@@ -483,7 +481,14 @@
   /*Fim Circuitos */
 
   /* Equipes */
-  
+  .equipes {
+    display: none;
+  }
+
+  .teams-accordion {
+    display: none;
+  }
+
   /*Fim Equipes */
 }
 

--- a/Challange_Web_Dev/css/wiki.css
+++ b/Challange_Web_Dev/css/wiki.css
@@ -200,7 +200,7 @@
     margin-bottom: 2rem;
     font-size: 1.5rem;
     font-weight: 200;
-    transition: .5s ease-in-out;
+    transition: .5s ease-in;
     height: 0;
   }
 
@@ -214,14 +214,21 @@
 .grid-label-content {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 1rem;
+  grid-template-rows: auto;
+  grid-template-areas:
+    "pilot carro"
+    "pilot stats";
+  margin-bottom: 1rem;
+  gap: 5rem;
 
   h3 {
     font-style: italic;
+    font-size: 2.5rem;
   }
 }
 
 .pilots-cards {
+  grid-area: pilot;
   display: flex;
   flex-direction: column;
 
@@ -248,7 +255,7 @@
   margin: 1rem;
 
   img {
-    width: 20%;
+    width: 35%;
   }
 
   h1 {
@@ -258,6 +265,62 @@
     font-weight: 400;
     color: var(--color-primary);
   }
+}
+
+.car-card {
+  grid-area: carro;
+
+  img {
+    width: 100%;
+  }
+}
+
+.stats-card {
+  grid-area: stats;
+  gap: 1rem;
+
+  h3 {
+    margin-bottom: 1rem;
+  }
+}
+
+.data {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 1.5rem;
+  font-weight: 200;
+  color: var(--font-primary-color);
+}
+
+.info {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.my-icon {
+  font-size: 2rem;
+}
+
+#icon-abt {
+  color: var(--cor-abt);
+}
+
+.position-number, .victory-number, .podium-number {
+  background-color: #f2f2f2;
+  padding: 1rem;
+  font-size: 2.5rem;
+  font-weight: 400;
+  color: var(--color-primary);
+}
+
+.position-number {
+  border-radius: 5px 0 0 5px;
+}
+
+.podium-number {
+  border-radius: 0 5px 5px 0;
 }
 
 

--- a/Challange_Web_Dev/views/wiki.html
+++ b/Challange_Web_Dev/views/wiki.html
@@ -36,7 +36,7 @@
       </div>
 
       <div class="container">
-        <div class="content">
+        <div class="content" id="blue">
           <div class="title-container">
             <h2>O Início de Tudo</h2>
           </div>
@@ -46,8 +46,8 @@
             </p>
           </div>
         </div>
-
-        <div class="content">
+        
+        <div class="content" id="red">
           <div class="title-container">
             <h2>Modernização</h2>
           </div>
@@ -61,7 +61,8 @@
           </div>
         </div>
 
-        <div class="content">
+
+        <div class="content" id="light-blue">
           <div class="title-container">
             <h2>Consolidação</h2>
           </div>
@@ -282,6 +283,6 @@
         </div>
       </footer>
       <!-- Fim Footer -->
-
-    </body>
-  </html>
+    </main>
+  </body>
+</html>

--- a/Challange_Web_Dev/views/wiki.html
+++ b/Challange_Web_Dev/views/wiki.html
@@ -33,47 +33,43 @@
         <h1>Nossa História:</h1>
       </div>
 
-    <div class="section-container mb-1" id="scroll-target">
-        <div class="content-wrapper">
-          <div class="content">
-            <div class="title-container">
-              <h2>O Início de Tudo</h2>
-            </div>
-            <div class="text-container">
-              <p>
-                A Fórmula E, iniciada em 2014, é uma série de corridas de carros elétricos criada para promover a mobilidade sustentável e acelerar a adoção de veículos elétricos. A ideia foi desenvolvida por Jean Todt, da FIA, e Alejandro Agag em 2011. A primeira temporada contou com dez equipes e corridas em várias cidades globais.
-              </p>
-            </div>
+      <div class="container">
+        <div class="content">
+          <div class="title-container">
+            <h2>O Início de Tudo</h2>
+          </div>
+          <div class="text-container">
+            <p>
+              A Fórmula E, iniciada em 2014, é uma série de corridas de carros elétricos criada para promover a mobilidade sustentável e acelerar a adoção de veículos elétricos. A ideia foi desenvolvida por Jean Todt, da FIA, e Alejandro Agag em 2011. A primeira temporada contou com dez equipes e corridas em várias cidades globais.
+            </p>
           </div>
         </div>
-      </div>
 
-      <div class="section-container mb-1" id="scroll-target">
-        <div class="content-wrapper">
-          <div class="content">
-            <div class="title-container">
-              <h2>Modernização</h2>
-            </div>
-            <div class="text-container">
-              <p>
-                Os carros eram inicialmente idênticos, mas a partir da segunda temporada, as equipes começaram a desenvolver seus próprios sistemas de propulsão. Em 2018, o carro Gen2 foi introduzido, eliminando a necessidade de trocas de carro durante as corridas. A Fórmula E também se destaca por sua interação com os fãs através do "FanBoost".
-              </p>
-            </div>
+        <div class="content">
+          <div class="title-container">
+            <h2>Modernização</h2>
+          </div>
+          <div class="text-container">
+            <p>
+              Os carros eram inicialmente idênticos, mas a partir da segunda temporada, as equipes começaram a
+              desenvolver seus próprios sistemas de propulsão. Em 2018, o carro Gen2 foi introduzido, eliminando a
+              necessidade de trocas de carro durante as corridas. A Fórmula E também se destaca por sua interação com os
+              fãs através do "FanBoost".
+            </p>
           </div>
         </div>
-      </div>
 
-      <div class="section-container mb-1" id="scroll-target">
-        <div class="content-wrapper">
-          <div class="content">
-            <div class="title-container">
-              <h2>Consolidação</h2>
-            </div>
-            <div class="text-container">
-              <p>
-                Grandes fabricantes como Audi, BMW, Mercedes-Benz, Jaguar e Porsche participam da competição. Em 2020, a Fórmula E foi reconhecida como um Campeonato Mundial pela FIA, consolidando seu prestígio. A série continua a ser uma plataforma para a inovação tecnológica e a sustentabilidade no automobilismo, promovendo um futuro mais verde.
-              </p>
-            </div>
+        <div class="content">
+          <div class="title-container">
+            <h2>Consolidação</h2>
+          </div>
+          <div class="text-container">
+            <p>
+              Grandes fabricantes como Audi, BMW, Mercedes-Benz, Jaguar e Porsche participam da competição. Em 2020, a
+              Fórmula E foi reconhecida como um Campeonato Mundial pela FIA, consolidando seu prestígio. A série
+              continua a ser uma plataforma para a inovação tecnológica e a sustentabilidade no automobilismo,
+              promovendo um futuro mais verde.
+            </p>
           </div>
         </div>
       </div>

--- a/Challange_Web_Dev/views/wiki.html
+++ b/Challange_Web_Dev/views/wiki.html
@@ -28,6 +28,8 @@
       <a href="home.html"><i class="fa-solid fa-angles-left"></i> Voltar</a>
       <img src="../img/Web/Logo-Formula-E.png" alt="logo" />
     </header>
+
+    <!-- História da Fórmula E -->
     <main>
       <div class="titulos">
         <h1>Nossa História:</h1>
@@ -73,6 +75,7 @@
           </div>
         </div>
       </div>
+      <!-- Fim História da Fórmula E -->
 
       <!-- Circuitos -->
       <div class="titulos">
@@ -84,6 +87,7 @@
           Os circuitos de corrida da Fórmula E são notáveis por serem urbanos, localizados no coração das principais cidades ao redor do mundo. Diferentemente das pistas tradicionais de corridas que geralmente estão situadas em áreas afastadas, os circuitos da Fórmula E são desenhados para passar por ruas e avenidas, criando um ambiente dinâmico e desafiador para os pilotos.
         </p>
       </div>
+      <!-- Fim Circuitos -->
 
       <!-- Equipes -->
       <div class="titulos">
@@ -235,9 +239,11 @@
           </div>
         </div>
       </div>
+      <!-- Fim Equipes -->
       
       <script src="../js/equipes.js"></script>
 
+      <!-- Footer -->
       <footer>
         <div class="footer-container">
           <div class="footer-content">
@@ -275,5 +281,7 @@
           </div>
         </div>
       </footer>
+      <!-- Fim Footer -->
+
     </body>
   </html>

--- a/Challange_Web_Dev/views/wiki.html
+++ b/Challange_Web_Dev/views/wiki.html
@@ -82,11 +82,83 @@
       <div class="titulos">
         <h1>Circuitos</h1>
       </div>
-      <div class="circuit-container">
-        <img class="circuit-img" src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
-        <p>
-          Os circuitos de corrida da Fórmula E são notáveis por serem urbanos, localizados no coração das principais cidades ao redor do mundo. Diferentemente das pistas tradicionais de corridas que geralmente estão situadas em áreas afastadas, os circuitos da Fórmula E são desenhados para passar por ruas e avenidas, criando um ambiente dinâmico e desafiador para os pilotos.
-        </p>
+      <div class="circuit-grid">
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <div class="circuit-name">
+            <span>Berlim</span>
+          </div>
+        </div>
+
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <div class="circuit-name">
+            <span>Berlim</span>
+          </div>
+        </div>
+        
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <div class="circuit-name">
+            <span>Berlim</span>
+          </div>
+        </div>
+        
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <div class="circuit-name">
+            <span>Berlim</span>
+          </div>
+        </div>
+
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <div class="circuit-name">
+            <span>Berlim</span>
+          </div>
+        </div>
+
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <div class="circuit-name">
+            <span>Berlim</span>
+          </div>
+        </div>
+
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <div class="circuit-name">
+            <span>Berlim</span>
+          </div>
+        </div>
+
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <div class="circuit-name">
+            <span>Berlim</span>
+          </div>
+        </div>
+
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <div class="circuit-name">
+            <span>Berlim</span>
+          </div>
+        </div>
+
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <div class="circuit-name">
+            <span>Berlim</span>
+          </div>
+        </div>
+        
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <div class="circuit-name">
+            <span>Berlim</span>
+          </div>
+        </div>
       </div>
       <!-- Fim Circuitos -->
 

--- a/Challange_Web_Dev/views/wiki.html
+++ b/Challange_Web_Dev/views/wiki.html
@@ -1,855 +1,845 @@
 <!DOCTYPE html>
 <html lang="pt-br">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Formula E</title>
-    <!-- Importe de CSS -->
-    <link rel="stylesheet" href="../css/styles.css" />
-    <link rel="stylesheet" href="../css/wiki.css" />
-    <!-- Importe de Fonte -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-      rel="stylesheet"
-    />
-    <!-- Importe de icones -->
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-      integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    />
-  </head>
-  <body>
-    <header class="header">
-      <a href="home.html"><i class="fa-solid fa-angles-left"></i> Voltar</a>
-      <img src="../img/Web/Logo-Formula-E.png" alt="logo" />
-    </header>
 
-    <!-- História da Fórmula E -->
-    <main>
-      <div class="titulos">
-        <h1>Nossa História:</h1>
-      </div>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Formula E</title>
+  <!-- Importe de CSS -->
+  <link rel="stylesheet" href="../css/styles.css" />
+  <link rel="stylesheet" href="../css/wiki.css" />
+  <!-- Importe de Fonte -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+    rel="stylesheet" />
+  <!-- Importe de icones -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+    integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A=="
+    crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
 
-      <div class="container">
-        <div class="content" id="blue">
-          <div class="title-container">
-            <h2>O Início de Tudo</h2>
-          </div>
-          <div class="text-container">
-            <p>
-              A Fórmula E, iniciada em 2014, é uma série de corridas de carros elétricos criada para promover a mobilidade sustentável e acelerar a adoção de veículos elétricos. A ideia foi desenvolvida por Jean Todt, da FIA, e Alejandro Agag em 2011. A primeira temporada contou com dez equipes e corridas em várias cidades globais.
-            </p>
-          </div>
+<body>
+  <header class="header">
+    <a href="home.html"><i class="fa-solid fa-angles-left"></i> Voltar</a>
+    <img src="../img/Web/Logo-Formula-E.png" alt="logo" />
+  </header>
+
+  <!-- História da Fórmula E -->
+  <main>
+    <div class="titulos">
+      <h1>Nossa História:</h1>
+    </div>
+
+    <div class="container">
+      <div class="content" id="blue">
+        <div class="title-container">
+          <h2>O Início de Tudo</h2>
         </div>
-        
-        <div class="content" id="red">
-          <div class="title-container">
-            <h2>Modernização</h2>
-          </div>
-          <div class="text-container">
-            <p>
-              Os carros eram inicialmente idênticos, mas a partir da segunda temporada, as equipes começaram a
-              desenvolver seus próprios sistemas de propulsão. Em 2018, o carro Gen2 foi introduzido, eliminando a
-              necessidade de trocas de carro durante as corridas. A Fórmula E também se destaca por sua interação com os
-              fãs através do "FanBoost".
-            </p>
-          </div>
-        </div>
-
-
-        <div class="content" id="light-blue">
-          <div class="title-container">
-            <h2>Consolidação</h2>
-          </div>
-          <div class="text-container">
-            <p>
-              Grandes fabricantes como Audi, BMW, Mercedes-Benz, Jaguar e Porsche participam da competição. Em 2020, a
-              Fórmula E foi reconhecida como um Campeonato Mundial pela FIA, consolidando seu prestígio. A série
-              continua a ser uma plataforma para a inovação tecnológica e a sustentabilidade no automobilismo,
-              promovendo um futuro mais verde.
-            </p>
-          </div>
+        <div class="text-container">
+          <p>
+            A Fórmula E, iniciada em 2014, é uma série de corridas de carros elétricos criada para promover a mobilidade
+            sustentável e acelerar a adoção de veículos elétricos. A ideia foi desenvolvida por Jean Todt, da FIA, e
+            Alejandro Agag em 2011. A primeira temporada contou com dez equipes e corridas em várias cidades globais.
+          </p>
         </div>
       </div>
-      <!-- Fim História da Fórmula E -->
 
-      <!-- Circuitos -->
-      <div class="titulos">
-        <h1>Circuitos</h1>
-      </div>
-      <div class="circuit-grid">
-        <div class="grid1">
-          <div class="berlim">
-            <div class="circuit-container">
-            <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
-              <div class="circuit-name">
-                <span>Berlim</span>
-              </div>
-            </div>
-          </div>
-  
-          <div class="mexico">
-            <div class="circuit-container">
-              <img src="../img/Circuitos/Circuito-Cidade-do-Mexico.jpg" alt="Circuito Cidade do México">
-              <div class="circuit-name">
-                <span>Cidade do México</span>
-              </div>
-            </div>
-          </div>
-          
-          <div class="diriyah">
-            <div class="circuit-container">
-              <img src="../img/Circuitos/Circuito-Diriyah.png" alt="Circuito de Diriyah">
-              <div class="circuit-name">
-                <span>Diriyah</span>
-              </div>
-            </div>
-          </div>
+      <div class="content" id="red">
+        <div class="title-container">
+          <h2>Modernização</h2>
         </div>
-        
-        <div class="londres">
+        <div class="text-container">
+          <p>
+            Os carros eram inicialmente idênticos, mas a partir da segunda temporada, as equipes começaram a
+            desenvolver seus próprios sistemas de propulsão. Em 2018, o carro Gen2 foi introduzido, eliminando a
+            necessidade de trocas de carro durante as corridas. A Fórmula E também se destaca por sua interação com os
+            fãs através do "FanBoost".
+          </p>
+        </div>
+      </div>
+
+
+      <div class="content" id="light-blue">
+        <div class="title-container">
+          <h2>Consolidação</h2>
+        </div>
+        <div class="text-container">
+          <p>
+            Grandes fabricantes como Audi, BMW, Mercedes-Benz, Jaguar e Porsche participam da competição. Em 2020, a
+            Fórmula E foi reconhecida como um Campeonato Mundial pela FIA, consolidando seu prestígio. A série
+            continua a ser uma plataforma para a inovação tecnológica e a sustentabilidade no automobilismo,
+            promovendo um futuro mais verde.
+          </p>
+        </div>
+      </div>
+    </div>
+    <!-- Fim História da Fórmula E -->
+
+    <!-- Circuitos -->
+    <div class="titulos">
+      <h1>Circuitos</h1>
+    </div>
+
+    <div class="circuit-grid">
+      <div class="grid1">
+        <div class="berlim">
           <div class="circuit-container">
-            <img src="../img/Circuitos/Circuito-Londres.png" alt="Circuito de Londres">
+            <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
             <div class="circuit-name">
-              <span>Londres</span>
+              <span>Berlim</span>
             </div>
           </div>
         </div>
 
-        <div class="grid2">
-          <div class="misano">
-            <div class="circuit-container">
-              <img src="../img/Circuitos/Circuito-Misano.webp" alt="Circuito de Misano">
+        <div class="mexico">
+          <div class="circuit-container">
+            <img src="../img/Circuitos/Circuito-Cidade-do-Mexico.jpg" alt="Circuito Cidade do México">
+            <div class="circuit-name">
+              <span>Cidade do México</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="diriyah">
+
+          <div class="circuit-container">
+            <img src="../img/Circuitos/Circuito-Diriyah.png" alt="Circuito de Diriyah">
+            <div class="circuit-name">
+              <span>Diriyah</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="londres">
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Londres.png" alt="Circuito de Londres">
+          <div class="circuit-name">
+            <span>Londres</span>
+          </div>
+        </div>
+      </div>
+      
+      <div class="grid2">
+        <div class="misano">
+          <div class="circuit-container">
+            <img src="../img/Circuitos/Circuito-Misano.webp" alt="Circuito de Misano">
+            <div class="circuit-name">
               <span>Misano</span>
             </div>
           </div>
-  
-          <div class="monaco">
-            <div class="circuit-container">
-              <img src="../img/Circuitos/Circuito-Monaco.webp" alt="Circuito de Mônaco">
+        </div>
+
+        <div class="monaco">
+          <div class="circuit-container">
+            <img src="../img/Circuitos/Circuito-Monaco.webp" alt="Circuito de Mônaco">
+            <div class="circuit-name">
               <span>Mônaco</span>
             </div>
           </div>
-  
-          <div class="portland">
-            <div class="circuit-container">
-              <img src="../img/Circuitos/Circuito-Portland.webp" alt="Circuito de Portland">
+        </div>
+
+        <div class="portland">
+          <div class="circuit-container">
+            <img src="../img/Circuitos/Circuito-Portland.webp" alt="Circuito de Portland">
+            <div class="circuit-name">
               <span>Portland</span>
             </div>
           </div>
         </div>
+      </div>
 
-        <div class="grid3">
-          <div class="circuit-container">
-            <img src="../img/Circuitos/Circuito-Sao-Paulo.jpg" alt="Circuito de São Paulo">
+      <div class="grid3">
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Sao-Paulo.jpg" alt="Circuito de São Paulo">
+          <div class="circuit-name">
             <span>São Paulo</span>
           </div>
-  
-          <div class="circuit-container">
-            <img src="../img/Circuitos/Circuito-Toquio.jpg" alt="Circuito de Tóquio">
+        </div>
+
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Toquio.jpg" alt="Circuito de Tóquio">
+          <div class="circuit-name">
             <span>Tóquio</span>
           </div>
-          
-          <div class="circuit-container">
-            <img src="../img/Circuitos/Circuito-Xangai.webp" alt="Circuito de Xangai">
+        </div>
+
+        <div class="circuit-container">
+          <img src="../img/Circuitos/Circuito-Xangai.webp" alt="Circuito de Xangai">
+          <div class="circuit-name">
             <span>Xangai</span>
           </div>
         </div>
       </div>
-      <!-- Fim Circuitos -->
+    </div>
 
-      <!-- Equipes -->
-      <div class="titulos">
-        <h1>Equipes</h1>
-      </div>
-      <div class="teams-accordion">
-        <div class="teams-content-box">
+    <!-- Fim Circuitos -->
 
-          <!-- Equipe ABT -->
-          <div class="label">
-            <img src="../img/Equipes/Logotipo_da_ABT_CUPRA_Formula_E_Team.png" alt="Logo da ABT Cupra Formula E Team"/>
-            <h2 class="title-label">ABT Cupra Formula E Team</h2>
-          </div>
-          <div class="label-content">
-            <div class="grid-label-content">
-              
-              <div class="pilots-cards">
-                <h3>Pilotos</h3>
-                <div class="pilot1">
-                  <div class="bar-color" id="abt"></div>
-                  <img src="../img/Pilotos/Lucas-Di-Grassi.png" alt="Piloto Lucas Di Grassi">
-                  <h1>Lucas Di Grassi</h1>
-                </div>
-                <div class="pilot2">
-                  <div class="bar-color" id="abt"></div>
-                  <img src="../img/Pilotos/Nico-Muller.png" alt="Piloto Nico Müller">
-                  <h1>Nico Müller</h1>
-                </div>
+    <!-- Equipes -->
+    <div class="titulos equipes">
+      <h1>Equipes</h1>
+    </div>
+    <div class="teams-accordion">
+      <div class="teams-content-box">
+        <!-- Equipe ABT -->
+        <div class="label">
+          <img src="../img/Equipes/Logotipo_da_ABT_CUPRA_Formula_E_Team.png" alt="Logo da ABT Cupra Formula E Team" />
+          <h2 class="title-label">ABT Cupra Formula E Team</h2>
+        </div>
+        <div class="label-content">
+          <div class="grid-label-content">
+
+            <div class="pilots-cards">
+              <h3>Pilotos</h3>
+              <div class="pilot1">
+                <div class="bar-color" id="abt"></div>
+                <img src="../img/Pilotos/Lucas-Di-Grassi.png" alt="Piloto Lucas Di Grassi">
+                <h1>Lucas Di Grassi</h1>
               </div>
+              <div class="pilot2">
+                <div class="bar-color" id="abt"></div>
+                <img src="../img/Pilotos/Nico-Muller.png" alt="Piloto Nico Müller">
+                <h1>Nico Müller</h1>
+              </div>
+            </div>
 
-              <div class="car-card">
-                  <h3>Carro</h3>
-                  <img src="../img/Carros/Carro-ABT.png" alt="Carro ABT">
-                </div>
+            <div class="car-card">
+              <h3>Carro</h3>
+              <img src="../img/Carros/Carro-ABT.png" alt="Carro ABT">
+            </div>
 
-                <div class="stats-card">
-                  <h3>Estatísticas</h3>
-                  <div class="data">
-                    <div class="position-number">
-                      <div class="info">
-                        <i class="fa-solid fa-table my-icon" id="icon-abt"></i>
-                        <span>Colocação</span>
-                      </div>
-                      <h4>10º</h4>
-                    </div>
-                    <div class="victory-number">
-                      <div class="info">
-                        <i class="fa-solid fa-trophy my-icon" id="icon-abt"></i>
-                        <span>Vitórias</span>
-                      </div>
-                      <h4>0</h4>
-                    </div>
-                    <div class="podium-number">
-                      <div class="info">
-                        <i class="fa-solid fa-ranking-star my-icon" id="icon-abt"></i>
-                        <span>Pódios</span>
-                      </div>
-                      <h4>0</h4>
-                    </div>
+            <div class="stats-card">
+              <h3>Estatísticas</h3>
+              <div class="data">
+                <div class="position-number">
+                  <div class="info">
+                    <i class="fa-solid fa-table my-icon" id="icon-abt"></i>
+                    <span>Colocação</span>
                   </div>
+                  <h4>10º</h4>
                 </div>
-
-              </div>
-            </div>
-          </div>
-
-          <!-- Equipe Andretti -->
-          <div class="label">
-            <img src="../img/Equipes/Logo-Andretti-Global.webp" alt="Logo da Andretti Formula E" />
-            <h2 class="title-label">Andretti Formula E</h2>
-          </div>
-          <div class="label-content">
-            <div class="grid-label-content">
-              
-              <div class="pilots-cards">
-                <h3>Pilotos</h3>
-                <div class="pilot1">
-                  <div class="bar-color" id="andretti"></div>
-                  <img src="../img/Pilotos/Jake-Dennis.png" alt="Piloto Jake Dennis">
-                  <h1>Jake Dennis</h1>
-                </div>
-                <div class="pilot2">
-                  <div class="bar-color" id="andretti"></div>
-                  <img src="../img/Pilotos/Norman-Nato.png" alt="Piloto Norman Nato">
-                  <h1>Nico Müller</h1>
-                </div>
-              </div>
-
-              <div class="car-card">
-                  <h3>Carro</h3>
-                  <img src="../img/Carros/Carro-Andretti.png" alt="Carro Andretti">
-                </div>
-
-                <div class="stats-card">
-                  <h3>Estatísticas</h3>
-                  <div class="data">
-                    <div class="position-number">
-                      <div class="info">
-                        <i class="fa-solid fa-table my-icon" id="icon-andretti"></i>
-                        <span>Colocação</span>
-                      </div>
-                      <h4>5º</h4>
-                    </div>
-                    <div class="victory-number">
-                      <div class="info">
-                        <i class="fa-solid fa-trophy my-icon" id="icon-andretti"></i>
-                        <span>Vitórias</span>
-                      </div>
-                      <h4>1</h4>
-                    </div>
-                    <div class="podium-number">
-                      <div class="info">
-                        <i class="fa-solid fa-ranking-star my-icon" id="icon-andretti"></i>
-                        <span>Pódios</span>
-                      </div>
-                      <h4>4</h4>
-                    </div>
+                <div class="victory-number">
+                  <div class="info">
+                    <i class="fa-solid fa-trophy my-icon" id="icon-abt"></i>
+                    <span>Vitórias</span>
                   </div>
+                  <h4>0</h4>
                 </div>
-
-              </div>
-            </div>
-          </div>
-
-          <!-- Equipe DS Penske -->
-          <div class="label">
-            <img src="../img/Equipes/LogoDS_PENSKE.webp.png" alt="Logo da DS Penske"/>
-            <h2 class="title-label">DS Penske</h2>
-          </div>
-          <div class="label-content">
-            <div class="grid-label-content">
-              
-              <div class="pilots-cards">
-                <h3>Pilotos</h3>
-                <div class="pilot1">
-                  <div class="bar-color" id="ds"></div>
-                  <img src="../img/Pilotos/Jean-Eric-Vergne.png" alt="Piloto Jean Eric Vergne">
-                  <h1>Lucas Di Grassi</h1>
-                </div>
-                <div class="pilot2">
-                  <div class="bar-color" id="ds"></div>
-                  <img src="../img/Pilotos/Stoffel-Vandoorne.png" alt="Piloto Stoffel Vandoorne">
-                  <h1>Nico Müller</h1>
-                </div>
-              </div>
-
-              <div class="car-card">
-                  <h3>Carro</h3>
-                  <img src="../img/Carros/Carro-DS-Penske.png" alt="Carro DS Penske">
-                </div>
-
-                <div class="stats-card">
-                  <h3>Estatísticas</h3>
-                  <div class="data">
-                    <div class="position-number">
-                      <div class="info">
-                        <i class="fa-solid fa-table my-icon" id="icon-ds"></i>
-                        <span>Colocação</span>
-                      </div>
-                      <h4>4º</h4>
-                    </div>
-                    <div class="victory-number">
-                      <div class="info">
-                        <i class="fa-solid fa-trophy my-icon" id="icon-ds"></i>
-                        <span>Vitórias</span>
-                      </div>
-                      <h4>0</h4>
-                    </div>
-                    <div class="podium-number">
-                      <div class="info">
-                        <i class="fa-solid fa-ranking-star my-icon" id="icon-ds"></i>
-                        <span>Pódios</span>
-                      </div>
-                      <h4>3</h4>
-                    </div>
+                <div class="podium-number">
+                  <div class="info">
+                    <i class="fa-solid fa-ranking-star my-icon" id="icon-abt"></i>
+                    <span>Pódios</span>
                   </div>
-                </div>
-
-              </div>
-            </div>
-          </div>
-
-          <!-- Equipe Envision -->
-          <div class="label">
-            <img src="../img/Equipes/Envision_Racing_logo.png" alt="Logo da Envision Racing"/>
-            <h2 class="title-label">Envision Racing</h2>
-          </div>
-          <div class="label-content">
-            <div class="grid-label-content">
-              
-              <div class="pilots-cards">
-                <h3>Pilotos</h3>
-                <div class="pilot1">
-                  <div class="bar-color" id="env"></div>
-                  <img src="../img/Pilotos/Robin-Frijns.png" alt="Piloto Robin Frijns">
-                  <h1>Robin Frijns</h1>
-                </div>
-                <div class="pilot2">
-                  <div class="bar-color" id="env"></div>
-                  <img src="../img/Pilotos/Sebastien-Buemi.png" alt="Piloto Sébastien Buemi">
-                  <h1>Sébastien Buemi</h1>
+                  <h4>0</h4>
                 </div>
               </div>
-
-              <div class="car-card">
-                  <h3>Carro</h3>
-                  <img src="../img/Carros/Carro-Envision.png" alt="Carro Envision">
-                </div>
-
-                <div class="stats-card">
-                  <h3>Estatísticas</h3>
-                  <div class="data">
-                    <div class="position-number">
-                      <div class="info">
-                        <i class="fa-solid fa-table my-icon" id="icon-env"></i>
-                        <span>Colocação</span>
-                      </div>
-                      <h4>8º</h4>
-                    </div>
-                    <div class="victory-number">
-                      <div class="info">
-                        <i class="fa-solid fa-trophy my-icon" id="icon-env"></i>
-                        <span>Vitórias</span>
-                      </div>
-                      <h4>0</h4>
-                    </div>
-                    <div class="podium-number">
-                      <div class="info">
-                        <i class="fa-solid fa-ranking-star my-icon" id="icon-env"></i>
-                        <span>Pódios</span>
-                      </div>
-                      <h4>2</h4>
-                    </div>
-                  </div>
-                </div>
-
-              </div>
-            </div>
-          </div>
-
-          <!-- Equipe ERT -->
-          <div class="label">
-            <img src="../img/Equipes/ERT_Formula_E_logo.png" alt="Logo da ERT Formula E"/>
-            <h2 class="title-label">ERT Formula E Team</h2>
-          </div>
-          <div class="label-content">
-            <div class="grid-label-content">
-              
-              <div class="pilots-cards">
-                <h3>Pilotos</h3>
-                <div class="pilot1">
-                  <div class="bar-color" id="ert"></div>
-                  <img src="../img/Pilotos/Dan-Ticktum.png" alt="Piloto Dan Ticktum">
-                  <h1>Dan Ticktum</h1>
-                </div>
-                <div class="pilot2">
-                  <div class="bar-color" id="ert"></div>
-                  <img src="../img/Pilotos/Sergio-Sette-Camara.png" alt="Piloto Sérgio Sette Câmara">
-                  <h1>Sérgio Sette Câmara</h1>
-                </div>
-              </div>
-
-              <div class="car-card">
-                  <h3>Carro</h3>
-                  <img src="../img/Carros/Carro-ERT.png" alt="Carro ERT">
-                </div>
-
-                <div class="stats-card">
-                  <h3>Estatísticas</h3>
-                  <div class="data">
-                    <div class="position-number">
-                      <div class="info">
-                        <i class="fa-solid fa-table my-icon" id="icon-ert"></i>
-                        <span>Colocação</span>
-                      </div>
-                      <h4>9º</h4>
-                    </div>
-                    <div class="victory-number">
-                      <div class="info">
-                        <i class="fa-solid fa-trophy my-icon" id="icon-ert"></i>
-                        <span>Vitórias</span>
-                      </div>
-                      <h4>0</h4>
-                    </div>
-                    <div class="podium-number">
-                      <div class="info">
-                        <i class="fa-solid fa-ranking-star my-icon" id="icon-ert"></i>
-                        <span>Pódios</span>
-                      </div>
-                      <h4>0</h4>
-                    </div>
-                  </div>
-                </div>
-
-              </div>
-            </div>
-          </div>
-
-          <!-- Equipe Jaguar -->
-          <div class="label">
-            <img src="../img/Equipes/Logo_da_Jaguar_Racing.png" alt="Logo da Jaguar TCS Racing"/>
-            <h2 class="title-label">Jaguar TCS Racing</h2>
-          </div>
-          <div class="label-content">
-            <div class="grid-label-content">
-              
-              <div class="pilots-cards">
-                <h3>Pilotos</h3>
-                <div class="pilot1">
-                  <div class="bar-color" id="jaguar"></div>
-                  <img src="../img/Pilotos/Mitch-Evans.png" alt="Piloto Mitch Evans">
-                  <h1>Mitch Evans</h1>
-                </div>
-                <div class="pilot2">
-                  <div class="bar-color" id="jaguar"></div>
-                  <img src="../img/Pilotos/Nick-Cassidy.png" alt="Piloto Nick Cassidy">
-                  <h1>Nick Cassidy</h1>
-                </div>
-              </div>
-
-              <div class="car-card">
-                  <h3>Carro</h3>
-                  <img src="../img/Carros/Carro-Jaguar.png" alt="Carro Jaguar">
-                </div>
-
-                <div class="stats-card">
-                  <h3>Estatísticas</h3>
-                  <div class="data">
-                    <div class="position-number">
-                      <div class="info">
-                        <i class="fa-solid fa-table my-icon" id="icon-jaguar"></i>
-                        <span>Colocação</span>
-                      </div>
-                      <h4>1º</h4>
-                    </div>
-                    <div class="victory-number">
-                      <div class="info">
-                        <i class="fa-solid fa-trophy my-icon" id="icon-jaguar"></i>
-                        <span>Vitórias</span>
-                      </div>
-                      <h4>3</h4>
-                    </div>
-                    <div class="podium-number">
-                      <div class="info">
-                        <i class="fa-solid fa-ranking-star my-icon" id="icon-jaguar"></i>
-                        <span>Pódios</span>
-                      </div>
-                      <h4>9</h4>
-                    </div>
-                  </div>
-                </div>
-
-              </div>
-            </div>
-          </div>
-
-          <!-- Equipe Mahindra -->
-          <div class="label">
-            <img src="../img/Equipes/LogoMahindra.png" alt="Logo da Mahindra Racing"/>
-            <h2 class="title-label">Mahindra Racing</h2>
-          </div>
-          <div class="label-content">
-            <div class="grid-label-content">
-              
-              <div class="pilots-cards">
-                <h3>Pilotos</h3>
-                <div class="pilot1">
-                  <div class="bar-color" id="mah"></div>
-                  <img src="../img/Pilotos/Edoardo-Motara.png" alt="Piloto Edoardo Motara">
-                  <h1>Edoardo Motara</h1>
-                </div>
-                <div class="pilot2">
-                  <div class="bar-color" id="mah"></div>
-                  <img src="../img/Pilotos/Nyck-De-Vries.png" alt="Piloto Nyck De Vries">
-                  <h1>Nyck De Vries</h1>
-                </div>
-              </div>
-
-              <div class="car-card">
-                  <h3>Carro</h3>
-                  <img src="../img/Carros/Carro-Mahindra.png" alt="Carro Mahindra">
-                </div>
-
-                <div class="stats-card">
-                  <h3>Estatísticas</h3>
-                  <div class="data">
-                    <div class="position-number">
-                      <div class="info">
-                        <i class="fa-solid fa-table my-icon" id="icon-mah"></i>
-                        <span>Colocação</span>
-                      </div>
-                      <h4>11º</h4>
-                    </div>
-                    <div class="victory-number">
-                      <div class="info">
-                        <i class="fa-solid fa-trophy my-icon" id="icon-mah"></i>
-                        <span>Vitórias</span>
-                      </div>
-                      <h4>0</h4>
-                    </div>
-                    <div class="podium-number">
-                      <div class="info">
-                        <i class="fa-solid fa-ranking-star my-icon" id="icon-mah"></i>
-                        <span>Pódios</span>
-                      </div>
-                      <h4>0</h4>
-                    </div>
-                  </div>
-                </div>
-
-              </div>
-            </div>
-          </div>
-
-          <!-- Equipe Maserati -->
-          <div class="label">
-            <img src="../img/Equipes/LogoMaserati.png" alt="Logo da Maserati MSG Racing"/>
-            <h2 class="title-label">Maserati MSG Racing</h2>
-          </div>
-          <div class="label-content">
-            <div class="grid-label-content">
-              
-              <div class="pilots-cards">
-                <h3>Pilotos</h3>
-                <div class="pilot1">
-                  <div class="bar-color" id="mas"></div>
-                  <img src="../img/Pilotos/Jehan-Daruvala.png" alt="Piloto Jehan Daruvala">
-                  <h1>Jehan Daruvala</h1>
-                </div>
-                <div class="pilot2">
-                  <div class="bar-color" id="mas"></div>
-                  <img src="../img/Pilotos/Maximilian-Gunther.png" alt="Piloto Maximilian Günther">
-                  <h1>Maximilian Günther</h1>
-                </div>
-              </div>
-
-              <div class="car-card">
-                  <h3>Carro</h3>
-                  <img src="../img/Carros/Carro-Maserati.png" alt="Carro Maserati">
-                </div>
-
-                <div class="stats-card">
-                  <h3>Estatísticas</h3>
-                  <div class="data">
-                    <div class="position-number">
-                      <div class="info">
-                        <i class="fa-solid fa-table my-icon" id="icon-mas"></i>
-                        <span>Colocação</span>
-                      </div>
-                      <h4>6º</h4>
-                    </div>
-                    <div class="victory-number">
-                      <div class="info">
-                        <i class="fa-solid fa-trophy my-icon" id="icon-mas"></i>
-                        <span>Vitórias</span>
-                      </div>
-                      <h4>1</h4>
-                    </div>
-                    <div class="podium-number">
-                      <div class="info">
-                        <i class="fa-solid fa-ranking-star my-icon" id="icon-mas"></i>
-                        <span>Pódios</span>
-                      </div>
-                      <h4>2</h4>
-                    </div>
-                  </div>
-                </div>
-
-              </div>
-            </div>
-          </div>
-
-          <!-- Equipe Mclaren -->
-          <div class="label">
-            <img src="../img/Equipes/NEOMMclarenLogo.png" alt="Neom Mclaren Formula E Team" />
-            <h2 class="title-label">Neom Mclaren Formula E Team</h2>
-          </div>
-          <div class="label-content">
-            <div class="grid-label-content">
-              
-              <div class="pilots-cards">
-                <h3>Pilotos</h3>
-                <div class="pilot1">
-                  <div class="bar-color" id="mcl"></div>
-                  <img src="../img/Pilotos/Jake-Hughes.png" alt="Piloto Jake-Hughes">
-                  <h1>Jake Hughes</h1>
-                </div>
-                <div class="pilot2">
-                  <div class="bar-color" id="mcl"></div>
-                  <img src="../img/Pilotos/Sam-Bird.png" alt="Piloto Sam Bird">
-                  <h1>Sam Bird</h1>
-                </div>
-              </div>
-
-              <div class="car-card">
-                  <h3>Carro</h3>
-                  <img src="../img/Carros/Carro-Mclaren.png" alt="Carro Mclaren">
-                </div>
-
-                <div class="stats-card">
-                  <h3>Estatísticas</h3>
-                  <div class="data">
-                    <div class="position-number">
-                      <div class="info">
-                        <i class="fa-solid fa-table my-icon" id="icon-mcl"></i>
-                        <span>Colocação</span>
-                      </div>
-                      <h4>7º</h4>
-                    </div>
-                    <div class="victory-number">
-                      <div class="info">
-                        <i class="fa-solid fa-trophy my-icon" id="icon-mcl"></i>
-                        <span>Vitórias</span>
-                      </div>
-                      <h4>1</h4>
-                    </div>
-                    <div class="podium-number">
-                      <div class="info">
-                        <i class="fa-solid fa-ranking-star my-icon" id="icon-mcl"></i>
-                        <span>Pódios</span>
-                      </div>
-                      <h4>1</h4>
-                    </div>
-                  </div>
-                </div>
-
-              </div>
-            </div>
-          </div>
-
-          <!-- Equipe ABT -->
-          <div class="label">
-            <img src="../img/Equipes/NissanLogo.png" alt="Logo da Nissan Formula E Team" />
-            <h2 class="title-label">Nissan Formula E Team</h2>
-          </div>
-          <div class="label-content">
-            <div class="grid-label-content">
-              
-              <div class="pilots-cards">
-                <h3>Pilotos</h3>
-                <div class="pilot1">
-                  <div class="bar-color" id="nissan"></div>
-                  <img src="../img/Pilotos/Oliver-Rowland.png" alt="Piloto Oliver Rowland">
-                  <h1>Oliver Rowland</h1>
-                </div>
-                <div class="pilot2">
-                  <div class="bar-color" id="nissan"></div>
-                  <img src="../img/Pilotos/Sacha-Fenestraz.png" alt="Piloto Sacha Fenestraz">
-                  <h1>Sacha Fenestraz</h1>
-                </div>
-              </div>
-
-              <div class="car-card">
-                  <h3>Carro</h3>
-                  <img src="../img/Carros/Carro-Nissan.png" alt="Carro Nissan">
-                </div>
-
-                <div class="stats-card">
-                  <h3>Estatísticas</h3>
-                  <div class="data">
-                    <div class="position-number">
-                      <div class="info">
-                        <i class="fa-solid fa-table my-icon" id="icon-nissan"></i>
-                        <span>Colocação</span>
-                      </div>
-                      <h4>3º</h4>
-                    </div>
-                    <div class="victory-number">
-                      <div class="info">
-                        <i class="fa-solid fa-trophy my-icon" id="icon-nissan"></i>
-                        <span>Vitórias</span>
-                      </div>
-                      <h4>1</h4>
-                    </div>
-                    <div class="podium-number">
-                      <div class="info">
-                        <i class="fa-solid fa-ranking-star my-icon" id="icon-nissan"></i>
-                        <span>Pódios</span>
-                      </div>
-                      <h4>6</h4>
-                    </div>
-                  </div>
-                </div>
-
-              </div>
-            </div>
-          </div>
-
-          <!-- Equipe Porsche -->
-          <div class="label">
-            <img src="../img/Equipes/Porsche_Formula_E.png" alt="Logo da TAG Heuer Porsche"/>
-            <h2 class="title-label">TAG Heuer Porsche</h2>
-          </div>
-          <div class="label-content">
-            <div class="grid-label-content">
-              
-              <div class="pilots-cards">
-                <h3>Pilotos</h3>
-                <div class="pilot1">
-                  <div class="bar-color" id="porsche"></div>
-                  <img src="../img/Pilotos/Pascal-Wehrlein.png" alt="Piloto Pascal Wehrlein">
-                  <h1>Pascal Wehrlein</h1>
-                </div>
-                <div class="pilot2">
-                  <div class="bar-color" id="porsche"></div>
-                  <img src="../img/Pilotos/Antonio-Felix-Da-Costa.png" alt="Piloto António Félix da Costa">
-                  <h1>Piloto António Félix da Costa</h1>
-                </div>
-              </div>
-
-              <div class="car-card">
-                  <h3>Carro</h3>
-                  <img src="../img/Carros/Carro-Porsche.png" alt="Carro Porsche">
-                </div>
-
-                <div class="stats-card">
-                  <h3>Estatísticas</h3>
-                  <div class="data">
-                    <div class="position-number">
-                      <div class="info">
-                        <i class="fa-solid fa-table my-icon" id="icon-porsche"></i>
-                        <span>Colocação</span>
-                      </div>
-                      <h4>2º</h4>
-                    </div>
-                    <div class="victory-number">
-                      <div class="info">
-                        <i class="fa-solid fa-trophy my-icon" id="icon-porsche"></i>
-                        <span>Vitórias</span>
-                      </div>
-                      <h4>3</h4>
-                    </div>
-                    <div class="podium-number">
-                      <div class="info">
-                        <i class="fa-solid fa-ranking-star my-icon" id="icon-porsche"></i>
-                        <span>Pódios</span>
-                      </div>
-                      <h4>3</h4>
-                    </div>
-                  </div>
-                </div>
-
-              </div>
-            </div>
-          </div>
-      <!-- Fim Equipes -->
-      
-      <script src="../js/equipes.js"></script>
-
-      <!-- Footer -->
-      <footer>
-        <div class="footer-container">
-          <div class="footer-content">
-            <div class="menu">
-              <div class="logo-footer">
-                <img src="../img/Web/Logo-Formula-E.png" alt="Logo" />
-              </div>
-              <ul class="no-decoration-list">
-                <li></li>
-                <li>
-                  <p>Faça parte da comunidade da Fórmula E</p>
-                </li>
-              </ul>
-            </div>
-            <ul class="no-decoration-list">
-              <li><h2>Páginas</h2></li>
-              <li>
-                <a href="home.html">Home</a>
-              </li>
-              <li><a href="wiki.html">Wiki</a></li>
-              <li><a href="classificacao.html">Classificação</a></li>
-              <li><a href="jogo.html">Jogo</a></li>
-            </ul>
-          </div>
-          <div class="copyright-container">
-            <div class="divider"></div>
-            <div class="footer-bottom">
-              <span>Formula E © 2024</span>
-              <a
-                href="https://github.com/RafaelPA13/Challange_Web_Dev"
-                target="_blank"
-                >Código Fonte</a
-              >
             </div>
           </div>
         </div>
-      </footer>
-      <!-- Fim Footer -->
-    </main>
+
+        <div class="label">
+          <img src="../img/Equipes/Logo-Andretti-Global.webp" alt="Logo da Andretti Formula E" />
+          <h2 class="title-label">Andretti Formula E</h2>
+        </div>
+        <div class="label-content">
+          <div class="grid-label-content">
+
+            <div class="pilots-cards">
+              <h3>Pilotos</h3>
+              <div class="pilot1">
+                <div class="bar-color" id="andretti"></div>
+                <img src="../img/Pilotos/Jake-Dennis.png" alt="Piloto Jake Dennis">
+                <h1>Jake Dennis</h1>
+              </div>
+              <div class="pilot2">
+                <div class="bar-color" id="andretti"></div>
+                <img src="../img/Pilotos/Norman-Nato.png" alt="Piloto Norman Nato">
+                <h1>Norman Nato</h1>
+              </div>
+            </div>
+
+            <div class="car-card">
+              <h3>Carro</h3>
+              <img src="../img/Carros/Carro-Andretti.png" alt="Carro Andretti">
+            </div>
+
+            <div class="stats-card">
+              <h3>Estatísticas</h3>
+              <div class="data">
+                <div class="position-number">
+                  <div class="info">
+                    <i class="fa-solid fa-table my-icon" id="icon-andretti"></i>
+                    <span>Colocação</span>
+                  </div>
+                  <h4>5º</h4>
+                </div>
+                <div class="victory-number">
+                  <div class="info">
+                    <i class="fa-solid fa-trophy my-icon" id="icon-andretti"></i>
+                    <span>Vitórias</span>
+                  </div>
+                  <h4>1</h4>
+                </div>
+                <div class="podium-number">
+                  <div class="info">
+                    <i class="fa-solid fa-ranking-star my-icon" id="icon-andretti"></i>
+                    <span>Pódios</span>
+                  </div>
+                  <h4>4</h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Equipe DS Penske -->
+        <div class="label">
+          <img src="../img/Equipes/LogoDS_PENSKE.webp.png" alt="Logo da DS Penske" />
+          <h2 class="title-label">DS Penske</h2>
+        </div>
+        <div class="label-content">
+          <div class="grid-label-content">
+
+            <div class="pilots-cards">
+              <h3>Pilotos</h3>
+              <div class="pilot1">
+                <div class="bar-color" id="ds"></div>
+                <img src="../img/Pilotos/Jean-Eric-Vergne.png" alt="Piloto Jean Eric Vergne">
+                <h1>Jean Eric Vergne</h1>
+              </div>
+              <div class="pilot2">
+                <div class="bar-color" id="ds"></div>
+                <img src="../img/Pilotos/Stoffel-Vandoorne.png" alt="Piloto Stoffel Vandoorne">
+                <h1>Nico Müller</h1>
+              </div>
+            </div>
+
+            <div class="car-card">
+              <h3>Carro</h3>
+              <img src="../img/Carros/Carro-DS-Penske.png" alt="Carro DS Penske">
+            </div>
+
+            <div class="stats-card">
+              <h3>Estatísticas</h3>
+              <div class="data">
+                <div class="position-number">
+                  <div class="info">
+                    <i class="fa-solid fa-table my-icon" id="icon-ds"></i>
+                    <span>Colocação</span>
+                  </div>
+                  <h4>4º</h4>
+                </div>
+                <div class="victory-number">
+                  <div class="info">
+                    <i class="fa-solid fa-trophy my-icon" id="icon-ds"></i>
+                    <span>Vitórias</span>
+                  </div>
+                  <h4>0</h4>
+                </div>
+                <div class="podium-number">
+                  <div class="info">
+                    <i class="fa-solid fa-ranking-star my-icon" id="icon-ds"></i>
+                    <span>Pódios</span>
+                  </div>
+                  <h4>3</h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Equipe Envision -->
+        <div class="label">
+          <img src="../img/Equipes/Envision_Racing_logo.png" alt="Logo da Envision Racing" />
+          <h2 class="title-label">Envision Racing</h2>
+        </div>
+        <div class="label-content">
+          <div class="grid-label-content">
+
+            <div class="pilots-cards">
+              <h3>Pilotos</h3>
+              <div class="pilot1">
+                <div class="bar-color" id="env"></div>
+                <img src="../img/Pilotos/Robin-Frijns.png" alt="Piloto Robin Frijns">
+                <h1>Robin Frijns</h1>
+              </div>
+              <div class="pilot2">
+                <div class="bar-color" id="env"></div>
+                <img src="../img/Pilotos/Sebastien-Buemi.png" alt="Piloto Sébastien Buemi">
+                <h1>Sébastien Buemi</h1>
+              </div>
+            </div>
+
+            <div class="car-card">
+              <h3>Carro</h3>
+              <img src="../img/Carros/Carro-Envision.png" alt="Carro Envision">
+            </div>
+
+            <div class="stats-card">
+              <h3>Estatísticas</h3>
+              <div class="data">
+                <div class="position-number">
+                  <div class="info">
+                    <i class="fa-solid fa-table my-icon" id="icon-env"></i>
+                    <span>Colocação</span>
+                  </div>
+                  <h4>8º</h4>
+                </div>
+                <div class="victory-number">
+                  <div class="info">
+                    <i class="fa-solid fa-trophy my-icon" id="icon-env"></i>
+                    <span>Vitórias</span>
+                  </div>
+                  <h4>0</h4>
+                </div>
+                <div class="podium-number">
+                  <div class="info">
+                    <i class="fa-solid fa-ranking-star my-icon" id="icon-env"></i>
+                    <span>Pódios</span>
+                  </div>
+                  <h4>2</h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Equipe ERT -->
+        <div class="label">
+          <img src="../img/Equipes/ERT_Formula_E_logo.png" alt="Logo da ERT Formula E" />
+          <h2 class="title-label">ERT Formula E Team</h2>
+        </div>
+        <div class="label-content">
+          <div class="grid-label-content">
+
+            <div class="pilots-cards">
+              <h3>Pilotos</h3>
+              <div class="pilot1">
+                <div class="bar-color" id="ert"></div>
+                <img src="../img/Pilotos/Dan-Ticktum.png" alt="Piloto Dan Ticktum">
+                <h1>Dan Ticktum</h1>
+              </div>
+              <div class="pilot2">
+                <div class="bar-color" id="ert"></div>
+                <img src="../img/Pilotos/Sergio-Sette-Camara.png" alt="Piloto Sérgio Sette Câmara">
+                <h1>Sérgio Sette Câmara</h1>
+              </div>
+            </div>
+
+            <div class="car-card">
+              <h3>Carro</h3>
+              <img src="../img/Carros/Carro-ERT.png" alt="Carro ERT">
+            </div>
+
+            <div class="stats-card">
+              <h3>Estatísticas</h3>
+              <div class="data">
+                <div class="position-number">
+                  <div class="info">
+                    <i class="fa-solid fa-table my-icon" id="icon-ert"></i>
+                    <span>Colocação</span>
+                  </div>
+                  <h4>9º</h4>
+                </div>
+                <div class="victory-number">
+                  <div class="info">
+                    <i class="fa-solid fa-trophy my-icon" id="icon-ert"></i>
+                    <span>Vitórias</span>
+                  </div>
+                  <h4>0</h4>
+                </div>
+                <div class="podium-number">
+                  <div class="info">
+                    <i class="fa-solid fa-ranking-star my-icon" id="icon-ert"></i>
+                    <span>Pódios</span>
+                  </div>
+                  <h4>0</h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Equipe Jaguar -->
+        <div class="label">
+          <img src="../img/Equipes/Logo_da_Jaguar_Racing.png" alt="Logo da Jaguar TCS Racing" />
+          <h2 class="title-label">Jaguar TCS Racing</h2>
+        </div>
+        <div class="label-content">
+          <div class="grid-label-content">
+
+            <div class="pilots-cards">
+              <h3>Pilotos</h3>
+              <div class="pilot1">
+                <div class="bar-color" id="jaguar"></div>
+                <img src="../img/Pilotos/Mitch-Evans.png" alt="Piloto Mitch Evans">
+                <h1>Mitch Evans</h1>
+              </div>
+              <div class="pilot2">
+                <div class="bar-color" id="jaguar"></div>
+                <img src="../img/Pilotos/Nick-Cassidy.png" alt="Piloto Nick Cassidy">
+                <h1>Nick Cassidy</h1>
+              </div>
+            </div>
+
+            <div class="car-card">
+              <h3>Carro</h3>
+              <img src="../img/Carros/Carro-Jaguar.png" alt="Carro Jaguar">
+            </div>
+
+            <div class="stats-card">
+              <h3>Estatísticas</h3>
+              <div class="data">
+                <div class="position-number">
+                  <div class="info">
+                    <i class="fa-solid fa-table my-icon" id="icon-jaguar"></i>
+                    <span>Colocação</span>
+                  </div>
+                  <h4>1º</h4>
+                </div>
+                <div class="victory-number">
+                  <div class="info">
+                    <i class="fa-solid fa-trophy my-icon" id="icon-jaguar"></i>
+                    <span>Vitórias</span>
+                  </div>
+                  <h4>3</h4>
+                </div>
+                <div class="podium-number">
+                  <div class="info">
+                    <i class="fa-solid fa-ranking-star my-icon" id="icon-jaguar"></i>
+                    <span>Pódios</span>
+                  </div>
+                  <h4>9</h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Equipe Mahindra -->
+        <div class="label">
+          <img src="../img/Equipes/LogoMahindra.png" alt="Logo da Mahindra Racing" />
+          <h2 class="title-label">Mahindra Racing</h2>
+        </div>
+        <div class="label-content">
+          <div class="grid-label-content">
+
+            <div class="pilots-cards">
+              <h3>Pilotos</h3>
+              <div class="pilot1">
+                <div class="bar-color" id="mah"></div>
+                <img src="../img/Pilotos/Edoardo-Motara.png" alt="Piloto Edoardo Motara">
+                <h1>Edoardo Motara</h1>
+              </div>
+              <div class="pilot2">
+                <div class="bar-color" id="mah"></div>
+                <img src="../img/Pilotos/Nyck-De-Vries.png" alt="Piloto Nyck De Vries">
+                <h1>Nyck De Vries</h1>
+              </div>
+            </div>
+
+            <div class="car-card">
+              <h3>Carro</h3>
+              <img src="../img/Carros/Carro-Mahindra.png" alt="Carro Mahindra">
+            </div>
+
+            <div class="stats-card">
+              <h3>Estatísticas</h3>
+              <div class="data">
+                <div class="position-number">
+                  <div class="info">
+                    <i class="fa-solid fa-table my-icon" id="icon-mah"></i>
+                    <span>Colocação</span>
+                  </div>
+                  <h4>11º</h4>
+                </div>
+                <div class="victory-number">
+                  <div class="info">
+                    <i class="fa-solid fa-trophy my-icon" id="icon-mah"></i>
+                    <span>Vitórias</span>
+                  </div>
+                  <h4>0</h4>
+                </div>
+                <div class="podium-number">
+                  <div class="info">
+                    <i class="fa-solid fa-ranking-star my-icon" id="icon-mah"></i>
+                    <span>Pódios</span>
+                  </div>
+                  <h4>0</h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Equipe Maserati -->
+        <div class="label">
+          <img src="../img/Equipes/LogoMaserati.png" alt="Logo da Maserati MSG Racing" />
+          <h2 class="title-label">Maserati MSG Racing</h2>
+        </div>
+        <div class="label-content">
+          <div class="grid-label-content">
+
+            <div class="pilots-cards">
+              <h3>Pilotos</h3>
+              <div class="pilot1">
+                <div class="bar-color" id="mas"></div>
+                <img src="../img/Pilotos/Jehan-Daruvala.png" alt="Piloto Jehan Daruvala">
+                <h1>Jehan Daruvala</h1>
+              </div>
+              <div class="pilot2">
+                <div class="bar-color" id="mas"></div>
+                <img src="../img/Pilotos/Maximilian-Gunther.png" alt="Piloto Maximilian Günther">
+                <h1>Maximilian Günther</h1>
+              </div>
+            </div>
+
+            <div class="car-card">
+              <h3>Carro</h3>
+              <img src="../img/Carros/Carro-Maserati.png" alt="Carro Maserati">
+            </div>
+
+            <div class="stats-card">
+              <h3>Estatísticas</h3>
+              <div class="data">
+                <div class="position-number">
+                  <div class="info">
+                    <i class="fa-solid fa-table my-icon" id="icon-mas"></i>
+                    <span>Colocação</span>
+                  </div>
+                  <h4>6º</h4>
+                </div>
+                <div class="victory-number">
+                  <div class="info">
+                    <i class="fa-solid fa-trophy my-icon" id="icon-mas"></i>
+                    <span>Vitórias</span>
+                  </div>
+                  <h4>1</h4>
+                </div>
+                <div class="podium-number">
+                  <div class="info">
+                    <i class="fa-solid fa-ranking-star my-icon" id="icon-mas"></i>
+                    <span>Pódios</span>
+                  </div>
+                  <h4>2</h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Equipe Mclaren -->
+        <div class="label">
+          <img src="../img/Equipes/NEOMMclarenLogo.png" alt="Neom Mclaren Formula E Team" />
+          <h2 class="title-label">Neom Mclaren Formula E Team</h2>
+        </div>
+        <div class="label-content">
+          <div class="grid-label-content">
+
+
+            <div class="pilots-cards">
+              <h3>Pilotos</h3>
+              <div class="pilot1">
+                <div class="bar-color" id="mcl"></div>
+                <img src="../img/Pilotos/Jake-Hughes.png" alt="Piloto Jake-Hughes">
+                <h1>Jake Hughes</h1>
+              </div>
+              <div class="pilot2">
+                <div class="bar-color" id="mcl"></div>
+                <img src="../img/Pilotos/Sam-Bird.png" alt="Piloto Sam Bird">
+                <h1>Sam Bird</h1>
+              </div>
+            </div>
+
+            <div class="car-card">
+              <h3>Carro</h3>
+              <img src="../img/Carros/Carro-Mclaren.png" alt="Carro Mclaren">
+            </div>
+
+            <div class="stats-card">
+              <h3>Estatísticas</h3>
+              <div class="data">
+                <div class="position-number">
+                  <div class="info">
+                    <i class="fa-solid fa-table my-icon" id="icon-mcl"></i>
+                    <span>Colocação</span>
+                  </div>
+                  <h4>7º</h4>
+                </div>
+                <div class="victory-number">
+                  <div class="info">
+                    <i class="fa-solid fa-trophy my-icon" id="icon-mcl"></i>
+                    <span>Vitórias</span>
+                  </div>
+                  <h4>1</h4>
+                </div>
+                <div class="podium-number">
+                  <div class="info">
+                    <i class="fa-solid fa-ranking-star my-icon" id="icon-mcl"></i>
+                    <span>Pódios</span>
+                  </div>
+                  <h4>1</h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Equipe Nissan -->
+        <div class="label">
+          <img src="../img/Equipes/NissanLogo.png" alt="Nissan Formula E Team" />
+          <h2 class="title-label">Nissan Formula E Team</h2>
+        </div>
+        <div class="label-content">
+          <div class="grid-label-content">
+
+
+            <div class="pilots-cards">
+              <h3>Pilotos</h3>
+              <div class="pilot1">
+                <div class="bar-color" id="nissan"></div>
+                <img src="../img/Pilotos/Oliver-Rowland.png" alt="Piloto Oliver Rowland">
+                <h1>Oliver Rowland</h1>
+              </div>
+              <div class="pilot2">
+                <div class="bar-color" id="nissan"></div>
+                <img src="../img/Pilotos/Sacha-Fenestraz.png" alt="Piloto Sacha Fenestraz">
+                <h1>Sacha Fenestraz</h1>
+              </div>
+            </div>
+
+            <div class="car-card">
+              <h3>Carro</h3>
+              <img src="../img/Carros/Carro-Nissan.png" alt="Carro Nissan">
+            </div>
+
+            <div class="stats-card">
+              <h3>Estatísticas</h3>
+              <div class="data">
+                <div class="position-number">
+                  <div class="info">
+                    <i class="fa-solid fa-table my-icon" id="icon-nissan"></i>
+                    <span>Colocação</span>
+                  </div>
+                  <h4>3º</h4>
+                </div>
+                <div class="victory-number">
+                  <div class="info">
+                    <i class="fa-solid fa-trophy my-icon" id="icon-nissan"></i>
+                    <span>Vitórias</span>
+                  </div>
+                  <h4>1</h4>
+                </div>
+                <div class="podium-number">
+                  <div class="info">
+                    <i class="fa-solid fa-ranking-star my-icon" id="icon-nissan"></i>
+                    <span>Pódios</span>
+                  </div>
+                  <h4>6</h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Equipe Porsche -->
+        <div class="label">
+          <img src="../img/Equipes/Porsche_Formula_E.png" alt="Logo da TAG Heuer Porsche" />
+          <h2 class="title-label">TAG Heuer Porsche</h2>
+        </div>
+        <div class="label-content">
+          <div class="grid-label-content">
+
+            <div class="pilots-cards">
+              <h3>Pilotos</h3>
+              <div class="pilot1">
+                <div class="bar-color" id="porsche"></div>
+                <img src="../img/Pilotos/Pascal-Wehrlein.png" alt="Piloto Pascal Wehrlein">
+                <h1>Pascal Wehrlein</h1>
+              </div>
+              <div class="pilot2">
+                <div class="bar-color" id="porsche"></div>
+                <img src="../img/Pilotos/Antonio-Felix-Da-Costa.png" alt="Piloto António Félix da Costa">
+                <h1>Piloto António Félix da Costa</h1>
+              </div>
+            </div>
+
+            <div class="car-card">
+              <h3>Carro</h3>
+              <img src="../img/Carros/Carro-Porsche.png" alt="Carro Porsche">
+            </div>
+
+            <div class="stats-card">
+              <h3>Estatísticas</h3>
+              <div class="data">
+                <div class="position-number">
+                  <div class="info">
+                    <i class="fa-solid fa-table my-icon" id="icon-porsche"></i>
+                    <span>Colocação</span>
+                  </div>
+                  <h4>2º</h4>
+                </div>
+                <div class="victory-number">
+                  <div class="info">
+                    <i class="fa-solid fa-trophy my-icon" id="icon-porsche"></i>
+                    <span>Vitórias</span>
+                  </div>
+                  <h4>3</h4>
+                </div>
+                <div class="podium-number">
+                  <div class="info">
+                    <i class="fa-solid fa-ranking-star my-icon" id="icon-porsche"></i>
+                    <span>Pódios</span>
+                  </div>
+                  <h4>3</h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Fim Equipes -->
+
+    <script src="../js/equipes.js"></script>
+
+    <!-- Footer -->
+    <footer>
+      <div class="footer-container">
+        <div class="footer-content">
+          <div class="menu">
+            <div class="logo-footer">
+              <img src="../img/Web/Logo-Formula-E.png" alt="Logo" />
+            </div>
+            <ul class="no-decoration-list">
+              <li></li>
+              <li>
+                <p>Faça parte da comunidade da Fórmula E</p>
+              </li>
+            </ul>
+          </div>
+          <ul class="no-decoration-list">
+            <li>
+              <h2>Páginas</h2>
+            </li>
+            <li>
+              <a href="home.html">Home</a>
+            </li>
+            <li><a href="wiki.html">Wiki</a></li>
+            <li><a href="classificacao.html">Classificação</a></li>
+            <li><a href="jogo.html">Jogo</a></li>
+          </ul>
+        </div>
+        <div class="copyright-container">
+          <div class="divider"></div>
+          <div class="footer-bottom">
+            <span>Formula E © 2024</span>
+            <a href="https://github.com/RafaelPA13/Challange_Web_Dev" target="_blank">Código Fonte</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <!-- Fim Footer -->
   </body>
 </html>

--- a/Challange_Web_Dev/views/wiki.html
+++ b/Challange_Web_Dev/views/wiki.html
@@ -227,6 +227,586 @@
               </div>
             </div>
           </div>
+
+          <!-- Equipe Andretti -->
+          <div class="label">
+            <img src="../img/Equipes/Logo-Andretti-Global.webp" alt="Logo da Andretti Formula E" />
+            <h2 class="title-label">Andretti Formula E</h2>
+          </div>
+          <div class="label-content">
+            <div class="grid-label-content">
+              
+              <div class="pilots-cards">
+                <h3>Pilotos</h3>
+                <div class="pilot1">
+                  <div class="bar-color" id="andretti"></div>
+                  <img src="../img/Pilotos/Jake-Dennis.png" alt="Piloto Jake Dennis">
+                  <h1>Jake Dennis</h1>
+                </div>
+                <div class="pilot2">
+                  <div class="bar-color" id="andretti"></div>
+                  <img src="../img/Pilotos/Norman-Nato.png" alt="Piloto Norman Nato">
+                  <h1>Nico Müller</h1>
+                </div>
+              </div>
+
+              <div class="car-card">
+                  <h3>Carro</h3>
+                  <img src="../img/Carros/Carro-Andretti.png" alt="Carro Andretti">
+                </div>
+
+                <div class="stats-card">
+                  <h3>Estatísticas</h3>
+                  <div class="data">
+                    <div class="position-number">
+                      <div class="info">
+                        <i class="fa-solid fa-table my-icon" id="icon-andretti"></i>
+                        <span>Colocação</span>
+                      </div>
+                      <h4>5º</h4>
+                    </div>
+                    <div class="victory-number">
+                      <div class="info">
+                        <i class="fa-solid fa-trophy my-icon" id="icon-andretti"></i>
+                        <span>Vitórias</span>
+                      </div>
+                      <h4>1</h4>
+                    </div>
+                    <div class="podium-number">
+                      <div class="info">
+                        <i class="fa-solid fa-ranking-star my-icon" id="icon-andretti"></i>
+                        <span>Pódios</span>
+                      </div>
+                      <h4>4</h4>
+                    </div>
+                  </div>
+                </div>
+
+              </div>
+            </div>
+          </div>
+
+          <!-- Equipe DS Penske -->
+          <div class="label">
+            <img src="../img/Equipes/LogoDS_PENSKE.webp.png" alt="Logo da DS Penske"/>
+            <h2 class="title-label">DS Penske</h2>
+          </div>
+          <div class="label-content">
+            <div class="grid-label-content">
+              
+              <div class="pilots-cards">
+                <h3>Pilotos</h3>
+                <div class="pilot1">
+                  <div class="bar-color" id="ds"></div>
+                  <img src="../img/Pilotos/Jean-Eric-Vergne.png" alt="Piloto Jean Eric Vergne">
+                  <h1>Lucas Di Grassi</h1>
+                </div>
+                <div class="pilot2">
+                  <div class="bar-color" id="ds"></div>
+                  <img src="../img/Pilotos/Stoffel-Vandoorne.png" alt="Piloto Stoffel Vandoorne">
+                  <h1>Nico Müller</h1>
+                </div>
+              </div>
+
+              <div class="car-card">
+                  <h3>Carro</h3>
+                  <img src="../img/Carros/Carro-DS-Penske.png" alt="Carro DS Penske">
+                </div>
+
+                <div class="stats-card">
+                  <h3>Estatísticas</h3>
+                  <div class="data">
+                    <div class="position-number">
+                      <div class="info">
+                        <i class="fa-solid fa-table my-icon" id="icon-ds"></i>
+                        <span>Colocação</span>
+                      </div>
+                      <h4>4º</h4>
+                    </div>
+                    <div class="victory-number">
+                      <div class="info">
+                        <i class="fa-solid fa-trophy my-icon" id="icon-ds"></i>
+                        <span>Vitórias</span>
+                      </div>
+                      <h4>0</h4>
+                    </div>
+                    <div class="podium-number">
+                      <div class="info">
+                        <i class="fa-solid fa-ranking-star my-icon" id="icon-ds"></i>
+                        <span>Pódios</span>
+                      </div>
+                      <h4>3</h4>
+                    </div>
+                  </div>
+                </div>
+
+              </div>
+            </div>
+          </div>
+
+          <!-- Equipe Envision -->
+          <div class="label">
+            <img src="../img/Equipes/Envision_Racing_logo.png" alt="Logo da Envision Racing"/>
+            <h2 class="title-label">Envision Racing</h2>
+          </div>
+          <div class="label-content">
+            <div class="grid-label-content">
+              
+              <div class="pilots-cards">
+                <h3>Pilotos</h3>
+                <div class="pilot1">
+                  <div class="bar-color" id="env"></div>
+                  <img src="../img/Pilotos/Robin-Frijns.png" alt="Piloto Robin Frijns">
+                  <h1>Robin Frijns</h1>
+                </div>
+                <div class="pilot2">
+                  <div class="bar-color" id="env"></div>
+                  <img src="../img/Pilotos/Sebastien-Buemi.png" alt="Piloto Sébastien Buemi">
+                  <h1>Sébastien Buemi</h1>
+                </div>
+              </div>
+
+              <div class="car-card">
+                  <h3>Carro</h3>
+                  <img src="../img/Carros/Carro-Envision.png" alt="Carro Envision">
+                </div>
+
+                <div class="stats-card">
+                  <h3>Estatísticas</h3>
+                  <div class="data">
+                    <div class="position-number">
+                      <div class="info">
+                        <i class="fa-solid fa-table my-icon" id="icon-env"></i>
+                        <span>Colocação</span>
+                      </div>
+                      <h4>8º</h4>
+                    </div>
+                    <div class="victory-number">
+                      <div class="info">
+                        <i class="fa-solid fa-trophy my-icon" id="icon-env"></i>
+                        <span>Vitórias</span>
+                      </div>
+                      <h4>0</h4>
+                    </div>
+                    <div class="podium-number">
+                      <div class="info">
+                        <i class="fa-solid fa-ranking-star my-icon" id="icon-env"></i>
+                        <span>Pódios</span>
+                      </div>
+                      <h4>2</h4>
+                    </div>
+                  </div>
+                </div>
+
+              </div>
+            </div>
+          </div>
+
+          <!-- Equipe ERT -->
+          <div class="label">
+            <img src="../img/Equipes/ERT_Formula_E_logo.png" alt="Logo da ERT Formula E"/>
+            <h2 class="title-label">ERT Formula E Team</h2>
+          </div>
+          <div class="label-content">
+            <div class="grid-label-content">
+              
+              <div class="pilots-cards">
+                <h3>Pilotos</h3>
+                <div class="pilot1">
+                  <div class="bar-color" id="ert"></div>
+                  <img src="../img/Pilotos/Dan-Ticktum.png" alt="Piloto Dan Ticktum">
+                  <h1>Dan Ticktum</h1>
+                </div>
+                <div class="pilot2">
+                  <div class="bar-color" id="ert"></div>
+                  <img src="../img/Pilotos/Sergio-Sette-Camara.png" alt="Piloto Sérgio Sette Câmara">
+                  <h1>Sérgio Sette Câmara</h1>
+                </div>
+              </div>
+
+              <div class="car-card">
+                  <h3>Carro</h3>
+                  <img src="../img/Carros/Carro-ERT.png" alt="Carro ERT">
+                </div>
+
+                <div class="stats-card">
+                  <h3>Estatísticas</h3>
+                  <div class="data">
+                    <div class="position-number">
+                      <div class="info">
+                        <i class="fa-solid fa-table my-icon" id="icon-ert"></i>
+                        <span>Colocação</span>
+                      </div>
+                      <h4>9º</h4>
+                    </div>
+                    <div class="victory-number">
+                      <div class="info">
+                        <i class="fa-solid fa-trophy my-icon" id="icon-ert"></i>
+                        <span>Vitórias</span>
+                      </div>
+                      <h4>0</h4>
+                    </div>
+                    <div class="podium-number">
+                      <div class="info">
+                        <i class="fa-solid fa-ranking-star my-icon" id="icon-ert"></i>
+                        <span>Pódios</span>
+                      </div>
+                      <h4>0</h4>
+                    </div>
+                  </div>
+                </div>
+
+              </div>
+            </div>
+          </div>
+
+          <!-- Equipe Jaguar -->
+          <div class="label">
+            <img src="../img/Equipes/Logo_da_Jaguar_Racing.png" alt="Logo da Jaguar TCS Racing"/>
+            <h2 class="title-label">Jaguar TCS Racing</h2>
+          </div>
+          <div class="label-content">
+            <div class="grid-label-content">
+              
+              <div class="pilots-cards">
+                <h3>Pilotos</h3>
+                <div class="pilot1">
+                  <div class="bar-color" id="jaguar"></div>
+                  <img src="../img/Pilotos/Mitch-Evans.png" alt="Piloto Mitch Evans">
+                  <h1>Mitch Evans</h1>
+                </div>
+                <div class="pilot2">
+                  <div class="bar-color" id="jaguar"></div>
+                  <img src="../img/Pilotos/Nick-Cassidy.png" alt="Piloto Nick Cassidy">
+                  <h1>Nick Cassidy</h1>
+                </div>
+              </div>
+
+              <div class="car-card">
+                  <h3>Carro</h3>
+                  <img src="../img/Carros/Carro-Jaguar.png" alt="Carro Jaguar">
+                </div>
+
+                <div class="stats-card">
+                  <h3>Estatísticas</h3>
+                  <div class="data">
+                    <div class="position-number">
+                      <div class="info">
+                        <i class="fa-solid fa-table my-icon" id="icon-jaguar"></i>
+                        <span>Colocação</span>
+                      </div>
+                      <h4>1º</h4>
+                    </div>
+                    <div class="victory-number">
+                      <div class="info">
+                        <i class="fa-solid fa-trophy my-icon" id="icon-jaguar"></i>
+                        <span>Vitórias</span>
+                      </div>
+                      <h4>3</h4>
+                    </div>
+                    <div class="podium-number">
+                      <div class="info">
+                        <i class="fa-solid fa-ranking-star my-icon" id="icon-jaguar"></i>
+                        <span>Pódios</span>
+                      </div>
+                      <h4>9</h4>
+                    </div>
+                  </div>
+                </div>
+
+              </div>
+            </div>
+          </div>
+
+          <!-- Equipe Mahindra -->
+          <div class="label">
+            <img src="../img/Equipes/LogoMahindra.png" alt="Logo da Mahindra Racing"/>
+            <h2 class="title-label">Mahindra Racing</h2>
+          </div>
+          <div class="label-content">
+            <div class="grid-label-content">
+              
+              <div class="pilots-cards">
+                <h3>Pilotos</h3>
+                <div class="pilot1">
+                  <div class="bar-color" id="mah"></div>
+                  <img src="../img/Pilotos/Edoardo-Motara.png" alt="Piloto Edoardo Motara">
+                  <h1>Edoardo Motara</h1>
+                </div>
+                <div class="pilot2">
+                  <div class="bar-color" id="mah"></div>
+                  <img src="../img/Pilotos/Nyck-De-Vries.png" alt="Piloto Nyck De Vries">
+                  <h1>Nyck De Vries</h1>
+                </div>
+              </div>
+
+              <div class="car-card">
+                  <h3>Carro</h3>
+                  <img src="../img/Carros/Carro-Mahindra.png" alt="Carro Mahindra">
+                </div>
+
+                <div class="stats-card">
+                  <h3>Estatísticas</h3>
+                  <div class="data">
+                    <div class="position-number">
+                      <div class="info">
+                        <i class="fa-solid fa-table my-icon" id="icon-mah"></i>
+                        <span>Colocação</span>
+                      </div>
+                      <h4>11º</h4>
+                    </div>
+                    <div class="victory-number">
+                      <div class="info">
+                        <i class="fa-solid fa-trophy my-icon" id="icon-mah"></i>
+                        <span>Vitórias</span>
+                      </div>
+                      <h4>0</h4>
+                    </div>
+                    <div class="podium-number">
+                      <div class="info">
+                        <i class="fa-solid fa-ranking-star my-icon" id="icon-mah"></i>
+                        <span>Pódios</span>
+                      </div>
+                      <h4>0</h4>
+                    </div>
+                  </div>
+                </div>
+
+              </div>
+            </div>
+          </div>
+
+          <!-- Equipe Maserati -->
+          <div class="label">
+            <img src="../img/Equipes/LogoMaserati.png" alt="Logo da Maserati MSG Racing"/>
+            <h2 class="title-label">Maserati MSG Racing</h2>
+          </div>
+          <div class="label-content">
+            <div class="grid-label-content">
+              
+              <div class="pilots-cards">
+                <h3>Pilotos</h3>
+                <div class="pilot1">
+                  <div class="bar-color" id="mas"></div>
+                  <img src="../img/Pilotos/Jehan-Daruvala.png" alt="Piloto Jehan Daruvala">
+                  <h1>Jehan Daruvala</h1>
+                </div>
+                <div class="pilot2">
+                  <div class="bar-color" id="mas"></div>
+                  <img src="../img/Pilotos/Maximilian-Gunther.png" alt="Piloto Maximilian Günther">
+                  <h1>Maximilian Günther</h1>
+                </div>
+              </div>
+
+              <div class="car-card">
+                  <h3>Carro</h3>
+                  <img src="../img/Carros/Carro-Maserati.png" alt="Carro Maserati">
+                </div>
+
+                <div class="stats-card">
+                  <h3>Estatísticas</h3>
+                  <div class="data">
+                    <div class="position-number">
+                      <div class="info">
+                        <i class="fa-solid fa-table my-icon" id="icon-mas"></i>
+                        <span>Colocação</span>
+                      </div>
+                      <h4>6º</h4>
+                    </div>
+                    <div class="victory-number">
+                      <div class="info">
+                        <i class="fa-solid fa-trophy my-icon" id="icon-mas"></i>
+                        <span>Vitórias</span>
+                      </div>
+                      <h4>1</h4>
+                    </div>
+                    <div class="podium-number">
+                      <div class="info">
+                        <i class="fa-solid fa-ranking-star my-icon" id="icon-mas"></i>
+                        <span>Pódios</span>
+                      </div>
+                      <h4>2</h4>
+                    </div>
+                  </div>
+                </div>
+
+              </div>
+            </div>
+          </div>
+
+          <!-- Equipe Mclaren -->
+          <div class="label">
+            <img src="../img/Equipes/NEOMMclarenLogo.png" alt="Neom Mclaren Formula E Team" />
+            <h2 class="title-label">Neom Mclaren Formula E Team</h2>
+          </div>
+          <div class="label-content">
+            <div class="grid-label-content">
+              
+              <div class="pilots-cards">
+                <h3>Pilotos</h3>
+                <div class="pilot1">
+                  <div class="bar-color" id="mcl"></div>
+                  <img src="../img/Pilotos/Jake-Hughes.png" alt="Piloto Jake-Hughes">
+                  <h1>Jake Hughes</h1>
+                </div>
+                <div class="pilot2">
+                  <div class="bar-color" id="mcl"></div>
+                  <img src="../img/Pilotos/Sam-Bird.png" alt="Piloto Sam Bird">
+                  <h1>Sam Bird</h1>
+                </div>
+              </div>
+
+              <div class="car-card">
+                  <h3>Carro</h3>
+                  <img src="../img/Carros/Carro-Mclaren.png" alt="Carro Mclaren">
+                </div>
+
+                <div class="stats-card">
+                  <h3>Estatísticas</h3>
+                  <div class="data">
+                    <div class="position-number">
+                      <div class="info">
+                        <i class="fa-solid fa-table my-icon" id="icon-mcl"></i>
+                        <span>Colocação</span>
+                      </div>
+                      <h4>7º</h4>
+                    </div>
+                    <div class="victory-number">
+                      <div class="info">
+                        <i class="fa-solid fa-trophy my-icon" id="icon-mcl"></i>
+                        <span>Vitórias</span>
+                      </div>
+                      <h4>1</h4>
+                    </div>
+                    <div class="podium-number">
+                      <div class="info">
+                        <i class="fa-solid fa-ranking-star my-icon" id="icon-mcl"></i>
+                        <span>Pódios</span>
+                      </div>
+                      <h4>1</h4>
+                    </div>
+                  </div>
+                </div>
+
+              </div>
+            </div>
+          </div>
+
+          <!-- Equipe ABT -->
+          <div class="label">
+            <img src="../img/Equipes/NissanLogo.png" alt="Logo da Nissan Formula E Team" />
+            <h2 class="title-label">Nissan Formula E Team</h2>
+          </div>
+          <div class="label-content">
+            <div class="grid-label-content">
+              
+              <div class="pilots-cards">
+                <h3>Pilotos</h3>
+                <div class="pilot1">
+                  <div class="bar-color" id="nissan"></div>
+                  <img src="../img/Pilotos/Oliver-Rowland.png" alt="Piloto Oliver Rowland">
+                  <h1>Oliver Rowland</h1>
+                </div>
+                <div class="pilot2">
+                  <div class="bar-color" id="nissan"></div>
+                  <img src="../img/Pilotos/Sacha-Fenestraz.png" alt="Piloto Sacha Fenestraz">
+                  <h1>Sacha Fenestraz</h1>
+                </div>
+              </div>
+
+              <div class="car-card">
+                  <h3>Carro</h3>
+                  <img src="../img/Carros/Carro-Nissan.png" alt="Carro Nissan">
+                </div>
+
+                <div class="stats-card">
+                  <h3>Estatísticas</h3>
+                  <div class="data">
+                    <div class="position-number">
+                      <div class="info">
+                        <i class="fa-solid fa-table my-icon" id="icon-nissan"></i>
+                        <span>Colocação</span>
+                      </div>
+                      <h4>3º</h4>
+                    </div>
+                    <div class="victory-number">
+                      <div class="info">
+                        <i class="fa-solid fa-trophy my-icon" id="icon-nissan"></i>
+                        <span>Vitórias</span>
+                      </div>
+                      <h4>1</h4>
+                    </div>
+                    <div class="podium-number">
+                      <div class="info">
+                        <i class="fa-solid fa-ranking-star my-icon" id="icon-nissan"></i>
+                        <span>Pódios</span>
+                      </div>
+                      <h4>6</h4>
+                    </div>
+                  </div>
+                </div>
+
+              </div>
+            </div>
+          </div>
+
+          <!-- Equipe Porsche -->
+          <div class="label">
+            <img src="../img/Equipes/Porsche_Formula_E.png" alt="Logo da TAG Heuer Porsche"/>
+            <h2 class="title-label">TAG Heuer Porsche</h2>
+          </div>
+          <div class="label-content">
+            <div class="grid-label-content">
+              
+              <div class="pilots-cards">
+                <h3>Pilotos</h3>
+                <div class="pilot1">
+                  <div class="bar-color" id="porsche"></div>
+                  <img src="../img/Pilotos/Pascal-Wehrlein.png" alt="Piloto Pascal Wehrlein">
+                  <h1>Pascal Wehrlein</h1>
+                </div>
+                <div class="pilot2">
+                  <div class="bar-color" id="porsche"></div>
+                  <img src="../img/Pilotos/Antonio-Felix-Da-Costa.png" alt="Piloto António Félix da Costa">
+                  <h1>Piloto António Félix da Costa</h1>
+                </div>
+              </div>
+
+              <div class="car-card">
+                  <h3>Carro</h3>
+                  <img src="../img/Carros/Carro-Porsche.png" alt="Carro Porsche">
+                </div>
+
+                <div class="stats-card">
+                  <h3>Estatísticas</h3>
+                  <div class="data">
+                    <div class="position-number">
+                      <div class="info">
+                        <i class="fa-solid fa-table my-icon" id="icon-porsche"></i>
+                        <span>Colocação</span>
+                      </div>
+                      <h4>2º</h4>
+                    </div>
+                    <div class="victory-number">
+                      <div class="info">
+                        <i class="fa-solid fa-trophy my-icon" id="icon-porsche"></i>
+                        <span>Vitórias</span>
+                      </div>
+                      <h4>3</h4>
+                    </div>
+                    <div class="podium-number">
+                      <div class="info">
+                        <i class="fa-solid fa-ranking-star my-icon" id="icon-porsche"></i>
+                        <span>Pódios</span>
+                      </div>
+                      <h4>3</h4>
+                    </div>
+                  </div>
+                </div>
+
+              </div>
+            </div>
+          </div>
       <!-- Fim Equipes -->
       
       <script src="../js/equipes.js"></script>

--- a/Challange_Web_Dev/views/wiki.html
+++ b/Challange_Web_Dev/views/wiki.html
@@ -192,27 +192,35 @@
                 </div>
               </div>
 
-                <div class="car-card">
+              <div class="car-card">
                   <h3>Carro</h3>
                   <img src="../img/Carros/Carro-ABT.png" alt="Carro ABT">
                 </div>
 
-                <div class="statistics-card">
+                <div class="stats-card">
                   <h3>Estatísticas</h3>
-                  <div class="position-number">
-                    <span>foto</span>
-                    <span>Colocação</span>
-                    <h4>10º</h4>
-                  </div>
-                  <div class="victory-number">
-                    <span>foto</span>
-                    <span>Vitórias</span>
-                    <h4>0</h4>
-                  </div>
-                  <div class="podium-number">
-                    <span>foto</span>
-                    <span>Pódios</span>
-                    <h4>0</h4>
+                  <div class="data">
+                    <div class="position-number">
+                      <div class="info">
+                        <i class="fa-solid fa-table my-icon" id="icon-abt"></i>
+                        <span>Colocação</span>
+                      </div>
+                      <h4>10º</h4>
+                    </div>
+                    <div class="victory-number">
+                      <div class="info">
+                        <i class="fa-solid fa-trophy my-icon" id="icon-abt"></i>
+                        <span>Vitórias</span>
+                      </div>
+                      <h4>0</h4>
+                    </div>
+                    <div class="podium-number">
+                      <div class="info">
+                        <i class="fa-solid fa-ranking-star my-icon" id="icon-abt"></i>
+                        <span>Pódios</span>
+                      </div>
+                      <h4>0</h4>
+                    </div>
                   </div>
                 </div>
 

--- a/Challange_Web_Dev/views/wiki.html
+++ b/Challange_Web_Dev/views/wiki.html
@@ -91,72 +91,65 @@
         </div>
 
         <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <img src="../img/Circuitos/Circuito-Cidade-do-Mexico.jpg" alt="Circuito Cidade do México">
           <div class="circuit-name">
-            <span>Berlim</span>
+            <span>Cidade do México</span>
           </div>
         </div>
         
         <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <img src="../img/Circuitos/Circuito-Diriyah.png" alt="Circuito de Diriyah">
           <div class="circuit-name">
-            <span>Berlim</span>
+            <span>Diriyah</span>
           </div>
         </div>
         
         <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <img src="../img/Circuitos/Circuito-Londres.png" alt="Circuito de Londres">
           <div class="circuit-name">
-            <span>Berlim</span>
+            <span>Londres</span>
           </div>
         </div>
 
         <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <img src="../img/Circuitos/Circuito-Misano.webp" alt="Circuito de Misano">
           <div class="circuit-name">
-            <span>Berlim</span>
+            <span>Misano</span>
           </div>
         </div>
 
         <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <img src="../img/Circuitos/Circuito-Monaco.webp" alt="Circuito de Mônaco">
           <div class="circuit-name">
-            <span>Berlim</span>
+            <span>Mônaco</span>
           </div>
         </div>
 
         <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <img src="../img/Circuitos/Circuito-Portland.webp" alt="Circuito de Portland">
           <div class="circuit-name">
-            <span>Berlim</span>
+            <span>Portland</span>
           </div>
         </div>
 
         <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <img src="../img/Circuitos/Circuito-Sao-Paulo.jpg" alt="Circuito de São Paulo">
           <div class="circuit-name">
-            <span>Berlim</span>
+            <span>São Paulo</span>
           </div>
         </div>
 
         <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <img src="../img/Circuitos/Circuito-Toquio.jpg" alt="Circuito de Tóquio">
           <div class="circuit-name">
-            <span>Berlim</span>
-          </div>
-        </div>
-
-        <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
-          <div class="circuit-name">
-            <span>Berlim</span>
+            <span>Tóquio</span>
           </div>
         </div>
         
         <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+          <img src="../img/Circuitos/Circuito-Xangai.webp" alt="Circuito de Xangai">
           <div class="circuit-name">
-            <span>Berlim</span>
+            <span>Xangai</span>
           </div>
         </div>
       </div>

--- a/Challange_Web_Dev/views/wiki.html
+++ b/Challange_Web_Dev/views/wiki.html
@@ -35,13 +35,6 @@
 
     <div class="section-container mb-1" id="scroll-target">
         <div class="content-wrapper">
-            <div class="image-container">
-                <img
-                  class="main-image"
-                  src="../img/Web/Imagem-Wiki-1.webp"
-                  alt="Formula E Carro"
-                />
-              </div>
           <div class="content">
             <div class="title-container">
               <h2>O Início de Tudo</h2>
@@ -67,25 +60,11 @@
               </p>
             </div>
           </div>
-          <div class="image-container">
-            <img
-              class="main-image"
-              src="../img/Web/Imagem-Wiki-2.webp"
-              alt="Formula E Carro"
-            />
-          </div>
         </div>
       </div>
 
       <div class="section-container mb-1" id="scroll-target">
         <div class="content-wrapper">
-            <div class="image-container">
-                <img
-                  class="main-image"
-                  src="../img/Web/Imagem-Wiki-3.jpg"
-                  alt="Formula E Carro"
-                />
-              </div>
           <div class="content">
             <div class="title-container">
               <h2>Consolidação</h2>

--- a/Challange_Web_Dev/views/wiki.html
+++ b/Challange_Web_Dev/views/wiki.html
@@ -83,72 +83,80 @@
         <h1>Circuitos</h1>
       </div>
       <div class="circuit-grid">
-        <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
-          <div class="circuit-name">
-            <span>Berlim</span>
+        <div class="grid1">
+          <div class="berlim">
+            <div class="circuit-container">
+            <img src="../img/Circuitos/Circuito-Berlim.webp" alt="Circuito de Berlim">
+              <div class="circuit-name">
+                <span>Berlim</span>
+              </div>
+            </div>
           </div>
-        </div>
-
-        <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Cidade-do-Mexico.jpg" alt="Circuito Cidade do México">
-          <div class="circuit-name">
-            <span>Cidade do México</span>
+  
+          <div class="mexico">
+            <div class="circuit-container">
+              <img src="../img/Circuitos/Circuito-Cidade-do-Mexico.jpg" alt="Circuito Cidade do México">
+              <div class="circuit-name">
+                <span>Cidade do México</span>
+              </div>
+            </div>
+          </div>
+          
+          <div class="diriyah">
+            <div class="circuit-container">
+              <img src="../img/Circuitos/Circuito-Diriyah.png" alt="Circuito de Diriyah">
+              <div class="circuit-name">
+                <span>Diriyah</span>
+              </div>
+            </div>
           </div>
         </div>
         
-        <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Diriyah.png" alt="Circuito de Diriyah">
-          <div class="circuit-name">
-            <span>Diriyah</span>
-          </div>
-        </div>
-        
-        <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Londres.png" alt="Circuito de Londres">
-          <div class="circuit-name">
-            <span>Londres</span>
+        <div class="londres">
+          <div class="circuit-container">
+            <img src="../img/Circuitos/Circuito-Londres.png" alt="Circuito de Londres">
+            <div class="circuit-name">
+              <span>Londres</span>
+            </div>
           </div>
         </div>
 
-        <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Misano.webp" alt="Circuito de Misano">
-          <div class="circuit-name">
-            <span>Misano</span>
+        <div class="grid2">
+          <div class="misano">
+            <div class="circuit-container">
+              <img src="../img/Circuitos/Circuito-Misano.webp" alt="Circuito de Misano">
+              <span>Misano</span>
+            </div>
+          </div>
+  
+          <div class="monaco">
+            <div class="circuit-container">
+              <img src="../img/Circuitos/Circuito-Monaco.webp" alt="Circuito de Mônaco">
+              <span>Mônaco</span>
+            </div>
+          </div>
+  
+          <div class="portland">
+            <div class="circuit-container">
+              <img src="../img/Circuitos/Circuito-Portland.webp" alt="Circuito de Portland">
+              <span>Portland</span>
+            </div>
           </div>
         </div>
 
-        <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Monaco.webp" alt="Circuito de Mônaco">
-          <div class="circuit-name">
-            <span>Mônaco</span>
-          </div>
-        </div>
-
-        <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Portland.webp" alt="Circuito de Portland">
-          <div class="circuit-name">
-            <span>Portland</span>
-          </div>
-        </div>
-
-        <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Sao-Paulo.jpg" alt="Circuito de São Paulo">
-          <div class="circuit-name">
+        <div class="grid3">
+          <div class="circuit-container">
+            <img src="../img/Circuitos/Circuito-Sao-Paulo.jpg" alt="Circuito de São Paulo">
             <span>São Paulo</span>
           </div>
-        </div>
-
-        <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Toquio.jpg" alt="Circuito de Tóquio">
-          <div class="circuit-name">
+  
+          <div class="circuit-container">
+            <img src="../img/Circuitos/Circuito-Toquio.jpg" alt="Circuito de Tóquio">
             <span>Tóquio</span>
           </div>
-        </div>
-        
-        <div class="circuit-container">
-          <img src="../img/Circuitos/Circuito-Xangai.webp" alt="Circuito de Xangai">
-          <div class="circuit-name">
+          
+          <div class="circuit-container">
+            <img src="../img/Circuitos/Circuito-Xangai.webp" alt="Circuito de Xangai">
             <span>Xangai</span>
           </div>
         </div>

--- a/Challange_Web_Dev/views/wiki.html
+++ b/Challange_Web_Dev/views/wiki.html
@@ -169,150 +169,56 @@
       </div>
       <div class="teams-accordion">
         <div class="teams-content-box">
+
+          <!-- Equipe ABT -->
           <div class="label">
             <img src="../img/Equipes/Logotipo_da_ABT_CUPRA_Formula_E_Team.png" alt="Logo da ABT Cupra Formula E Team"/>
             <h2 class="title-label">ABT Cupra Formula E Team</h2>
           </div>
           <div class="label-content">
-            <ul>
-              <li><h4>Pilotos:</h4> Robin Frijns, Nico Müller</li>
-              <li><h4>Classificação:</h4> 10º lugar (8 pontos)</li>
-              <li><h4>Vitórias:</h4> 0</li>
-              <li><h4>Pódios:</h4> 0</li>
-            </ul>
-          </div>
+            <div class="grid-label-content">
+              
+              <div class="pilots-cards">
+                <h3>Pilotos</h3>
+                <div class="pilot1">
+                  <div class="bar-color" id="abt"></div>
+                  <img src="../img/Pilotos/Lucas-Di-Grassi.png" alt="Piloto Lucas Di Grassi">
+                  <h1>Lucas Di Grassi</h1>
+                </div>
+                <div class="pilot2">
+                  <div class="bar-color" id="abt"></div>
+                  <img src="../img/Pilotos/Nico-Muller.png" alt="Piloto Nico Müller">
+                  <h1>Nico Müller</h1>
+                </div>
+              </div>
 
-          <div class="label">
-            <img src="../img/Equipes/Logo-Andretti-Global.webp" alt="Logo da Andretti Formula E">
-            <h2 class="title-label">Andretti Formula E</h2>
-          </div>
-          <div class="label-content">
-            <ul>
-              <li><h4>Pilotos:</h4> Jake Dennis, André Lotterer</li>
-              <li><h4>Classificação:</h4> 3º lugar (186 pontos)</li>
-              <li><h4>Vitórias:</h4> 2 (Dennis - 2)</li>
-              <li><h4>Pódios:</h4> 5 (Dennis - 4, Lotterer - 1)</li>
-            </ul>
-          </div>
+                <div class="car-card">
+                  <h3>Carro</h3>
+                  <img src="../img/Carros/Carro-ABT.png" alt="Carro ABT">
+                </div>
 
-          <div class="label">
-            <img src="../img/Equipes/LogoDS_PENSKE.webp.png" alt="Logo da DS Penske">
-            <h2 class="title-label">DS Penske</h2>
-          </div>
-          <div class="label-content">
-            <ul>
-              <li><h4>Pilotos:</h4> Stoffel Vandoorne, Jean-Éric Vergne</li>
-              <li><h4>Classificação:</h4> 5º lugar (164 pontos)</li>
-              <li><h4>Vitórias:</h4> 1 (Vergne - 1)</li>
-              <li><h4>Pódios:</h4> 3 (Vandoorne - 2, Vergne - 1)</li>
-            </ul>
-          </div>
+                <div class="statistics-card">
+                  <h3>Estatísticas</h3>
+                  <div class="position-number">
+                    <span>foto</span>
+                    <span>Colocação</span>
+                    <h4>10º</h4>
+                  </div>
+                  <div class="victory-number">
+                    <span>foto</span>
+                    <span>Vitórias</span>
+                    <h4>0</h4>
+                  </div>
+                  <div class="podium-number">
+                    <span>foto</span>
+                    <span>Pódios</span>
+                    <h4>0</h4>
+                  </div>
+                </div>
 
-          <div class="label">
-            <img src="../img/Equipes/Envision_Racing_logo.png" alt="Logo da Envision Racing">
-            <h2 class="title-label">Envision Racing</h2>
+              </div>
+            </div>
           </div>
-          <div class="label-content">
-            <ul>
-              <li><h4>Pilotos:</h4> Nick Cassidy, Sébastien Buemi</li>
-              <li><h4>Classificação:</h4> 2º lugar (228 pontos)</li>
-              <li><h4>Vitórias:</h4> 3 (Cassidy - 3)</li>
-              <li><h4>Pódios:</h4> 8 (Cassidy - 5, Buemi - 3)</li>
-            </ul>
-          </div>
-
-          <div class="label">
-            <img src="../img/Equipes/ERT_Formula_E_logo.png" alt="Logo da ERT Formula E Team">
-            <h2 class="title-label">ERT Formula E Team</h2>
-          </div>
-          <div class="label-content">
-            <ul>
-              <li><h4>Pilotos:</h4> Dan Ticktum, Sérgio Sette Câmara</li>
-              <li><h4>Classificação:</h4> 9º lugar (20 pontos)</li>
-              <li><h4>Vitórias:</h4> 0</li>
-              <li><h4>Pódios:</h4> 0</li>
-            </ul>
-          </div>
-
-          <div class="label">
-            <img src="../img/Equipes/Logo_da_Jaguar_Racing.png" alt="Logo da Jaguar TCS Racing">
-            <h2 class="title-label">Jaguar TCS Racing</h2>
-          </div>
-          <div class="label-content">
-            <ul>
-              <li><h4>Pilotos:</h4> Mitch Evans, Sam Bird</li>
-              <li><h4>Classificação:</h4> 4º lugar (178 pontos)</li>
-              <li><h4>Vitórias:</h4> 2 (Evans - 2)</li>
-              <li><h4>Pódios:</h4> 3 (Evans - 3)</li>
-            </ul>
-          </div>
-
-          <div class="label">
-            <img src="../img/Equipes/LogoMahindra.png" alt="Logo da Mahindra Racing">
-            <h2 class="title-label">Mahindra Racing</h2>
-          </div>
-          <div class="label-content">
-            <ul>
-              <li><h4>Pilotos:</h4> Lucas Di Grassi, Oliver Rowland</li>
-              <li><h4>Classificação:</h4> 8º lugar (80 pontos)</li>
-              <li><h4>Vitórias:</h4> 0</li>
-              <li><h4>Pódios:</h4> 1 (Di Grassi - 1)</li>
-            </ul>
-          </div>
-
-          <div class="label">
-            <img src="../img/Equipes/LogoMaserati.png" alt="Logo da Maserati MSG Racing">
-            <h2 class="title-label">Maserati MSG Racing</h2>
-          </div>
-          <div class="label-content">
-            <ul>
-              <li><h4>Pilotos:</h4> Edoardo Mortara, Maximilian Günther</li>
-              <li><h4>Classificação:</h4> 6º lugar (157 pontos)</li>
-              <li><h4>Vitórias:</h4> 1 (Günther - 1)</li>
-              <li><h4>Pódios:</h4> 4 (Mortara - 3, Günther - 1)</li>
-            </ul>
-          </div>
-
-          <div class="label">
-            <img src="../img/Equipes/NEOMMclarenLogo.png" alt="Logo da NEOM Mclaren Formula E">
-            <h2 class="title-label">NEOM Mclaren Formula E</h2>
-          </div>
-          <div class="label-content">
-            <ul>
-              <li><h4>Pilotos:</h4> René Rast, Jake Hughes</li>
-              <li><h4>Classificação:</h4> 7º lugar (144 pontos)</li>
-              <li><h4>Vitórias:</h4> 0</li>
-              <li><h4>Pódios:</h4> 2 (Rast - 2)</li>
-            </ul>
-          </div>
-
-          <div class="label">
-            <img src="../img/Equipes/NissanLogo.png" alt="Logo da Nissan Formula E Team">
-            <h2 class="title-label">Nissan Formula E Team</h2>
-          </div>
-          <div class="label-content">
-            <ul>
-              <li><h4>Pilotos:</h4> Norman Nato, Sacha Fenestraz</li>
-              <li><h4>Classificação:</h4> 11º lugar (2 pontos)</li>
-              <li><h4>Vitórias:</h4> 0</li>
-              <li><h4>Pódios:</h4> 0</li>
-            </ul>
-          </div>
-
-          <div class="label">
-            <img src="../img/Equipes/Porsche_Formula_E.png" alt="Logo da TAG Heuer Porsche">
-            <h2 class="title-label">TAG Heuer Porsche</h2>
-          </div>
-          <div class="label-content">
-            <ul>
-              <li><h4>Pilotos:</h4> Pascal Wehrlein, António Félix da Costa</li>
-              <li><h4>Classificação:</h4> 1º lugar (238 pontos)</li>
-              <li><h4>Vitórias:</h4> 5 (Wehrlein - 4, da Costa - 1)</li>
-              <li><h4>Pódios:</h4> 9 (Wehrlein - 6, da Costa - 3)</li>
-            </ul>
-          </div>
-        </div>
-      </div>
       <!-- Fim Equipes -->
       
       <script src="../js/equipes.js"></script>


### PR DESCRIPTION
### seção nossa história:
feita com _grid_ em três colunas e já com responsividade.

### seção circuitos:
também uso de _grid,_ entretanto, não funcionou muito bem.
a solução foi um ajuste com `margin-left: 15%`  que não ficou tão bom visualmente, mas foi útil.
houveram algumas mudanças no estilo dos _cards_ visando um melhor design.

### seção equipes:
modéstia a parte, ficou muito bom.
responsividade inexistente, pois, no projeto feito no **Figma** não havia nada declarado.
uso da parte responsiva apenas para esconder a seção por meio do `display: none`.

### tamanho de telas:
defini uma responsividade geral, tanto para tablets, quanto celulares.
valor em `max-width: 1200px`





(ps: aprova essa porra pq eu cansei)